### PR TITLE
Revert conditional on ServerEndpointExporter

### DIFF
--- a/example-graphql-tools/src/test/java/com/oembedler/moon/graphql/boot/GraphQLToolsSampleApplicationTest.java
+++ b/example-graphql-tools/src/test/java/com/oembedler/moon/graphql/boot/GraphQLToolsSampleApplicationTest.java
@@ -28,7 +28,6 @@ public class GraphQLToolsSampleApplicationTest {
         GraphQLResponse response = graphQLTestTemplate.postForResource("graphql/post-get-comments.graphql");
         assertNotNull(response);
         assertTrue(response.isOk());
-        System.out.println(response.getRawResponse().getBody());
         assertEquals("1", response.get("$.data.post.id"));
     }
 

--- a/example-graphql-tools/src/test/java/com/oembedler/moon/graphql/boot/SpringBootTestWithoutWebEnvironmentTest.java
+++ b/example-graphql-tools/src/test/java/com/oembedler/moon/graphql/boot/SpringBootTestWithoutWebEnvironmentTest.java
@@ -1,5 +1,6 @@
 package com.oembedler.moon.graphql.boot;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -10,6 +11,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class SpringBootTestWithoutWebEnvironmentTest {
 
     @Test
+    @Ignore
     public void loads_without_complaining_about_missing_ServerContainer() {
 
     }

--- a/graphql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphql/boot/GraphQLWebsocketAutoConfiguration.java
+++ b/graphql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphql/boot/GraphQLWebsocketAutoConfiguration.java
@@ -14,6 +14,8 @@ import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 import org.springframework.web.socket.server.standard.ServerEndpointRegistration;
 
+import javax.websocket.ContainerProvider;
+import javax.websocket.WebSocketContainer;
 import javax.websocket.server.ServerContainer;
 
 @Configuration
@@ -41,7 +43,7 @@ public class GraphQLWebsocketAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnBean(ServerContainer.class)
+    @ConditionalOnClass(ServerContainer.class)
     public ServerEndpointExporter serverEndpointExporter() {
         return new ServerEndpointExporter();
     }


### PR DESCRIPTION
Reverted conditional back to `@ConditionalOnClass` again. This leads to the requirement that unit tests using `@SpringBootTest` need to be started with a `webEnvironment` because otherwise they won't start at all complaining about a missing `ServerContainer` (fixes #150).