### PR TITLE
Add the ability to set HTTP headers in GraphQLTestTemplate.

### DIFF
--- a/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestTemplate.java
+++ b/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestTemplate.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StreamUtils;
@@ -27,6 +28,7 @@ public class GraphQLTestTemplate {
     private String graphqlMapping;
 
     private ObjectMapper objectMapper = new ObjectMapper();
+    private HttpHeaders headers = new HttpHeaders();
 
     private String createJsonQuery(String graphql, ObjectNode variables)
             throws JsonProcessingException {
@@ -46,6 +48,32 @@ public class GraphQLTestTemplate {
         try (InputStream inputStream = resource.getInputStream()) {
             return StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
         }
+    }
+
+    /**
+     * Add an HTTP header that will be sent with each request this sends.
+     *
+     * @param String Name (key) of HTTP header to add.
+     * @param String Value of HTTP header to add.
+     */
+    public void addHeader(String name, String value) {
+        headers.add(name, value);
+    }
+
+    /**
+     * Replace any associated HTTP headers with the provided headers.
+     *
+     * @param HttpHeaders Headers to use.
+     */
+    public void setHeaders(HttpHeaders newHeaders) {
+        headers = newHeaders
+    }
+
+    /**
+     * Clear all associated HTTP headers.
+     */
+    public void clearHeaders() {
+        setHeaders(new HttpHeaders());
     }
 
     /**
@@ -77,11 +105,11 @@ public class GraphQLTestTemplate {
     }
 
     public GraphQLResponse postMultipart(String query, String variables) {
-        return postRequest(RequestFactory.forMultipart(query, variables));
+        return postRequest(RequestFactory.forMultipart(query, variables, headers));
     }
 
     private GraphQLResponse post(String payload) {
-        return postRequest(RequestFactory.forJson(payload));
+        return postRequest(RequestFactory.forJson(payload, headers));
     }
 
     private GraphQLResponse postRequest(HttpEntity<Object> request) {

--- a/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/RequestFactory.java
+++ b/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/RequestFactory.java
@@ -11,18 +11,16 @@ class RequestFactory {
         // utility class
     }
 
-    static HttpEntity<Object> forJson(String json) {
-        HttpHeaders headers = new HttpHeaders();
+    static HttpEntity<Object> forJson(String json, HttpHeaders headers) {
         headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
         return new HttpEntity<>(json, headers);
     }
 
-    static HttpEntity<Object> forMultipart(String query, String variables) {
-        HttpHeaders headers = new HttpHeaders();
+    static HttpEntity<Object> forMultipart(String query, String variables, HttpHeaders headers) {
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         LinkedMultiValueMap<String, Object> values = new LinkedMultiValueMap<>();
-        values.add("query", forJson(query));
-        values.add("variables", forJson(variables));
+        values.add("query", forJson(query, headers));
+        values.add("variables", forJson(variables, headers));
         return new HttpEntity<>(values, headers);
     }
 


### PR DESCRIPTION
This is particularly useful for testing GraphQL servers that require some kind of authentication in the headers.

See #173 