### PR TITLE
fix(): actuator-metrics works without explicitly setting tracing-enabled to false

### DIFF
--- a/graphql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphql/boot/GraphQLInstrumentationAutoConfiguration.java
+++ b/graphql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphql/boot/GraphQLInstrumentationAutoConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfigu
 import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -44,7 +45,7 @@ public class GraphQLInstrumentationAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(value = "graphql.servlet.tracing-enabled", havingValue = "false")
+    @ConditionalOnExpression("${graphql.servlet.actuator-metrics:false} && !${graphql.servlet.tracing-enabled:false}")
     public TracingNoResolversInstrumentation tracingNoResolversInstrumentation() {
         return new TracingNoResolversInstrumentation();
     }

--- a/graphql-spring-boot-autoconfigure/src/test/java/com/oembedler/moon/graphql/boot/test/instrumentation/GraphQLInstrumentationAutoConfigurationTest.java
+++ b/graphql-spring-boot-autoconfigure/src/test/java/com/oembedler/moon/graphql/boot/test/instrumentation/GraphQLInstrumentationAutoConfigurationTest.java
@@ -76,12 +76,21 @@ public class GraphQLInstrumentationAutoConfigurationTest extends AbstractAutoCon
         load(DefaultConfiguration.class, "graphql.servlet.tracing-enabled=true", "graphql.servlet.actuator-metrics=true");
 
         Assert.assertNotNull(this.getContext().getBean(TracingInstrumentation.class));
-        this.getContext().getBean(TracingInstrumentation.class);
+        Assert.assertNotNull(this.getContext().getBean(MetricsInstrumentation.class));
+        this.getContext().getBean(TracingNoResolversInstrumentation.class);
     }
 
     @Test
-    public void tracingInstrumentationDisabledndMetricsEnabled() {
+    public void tracingInstrumentationDisabledAndMetricsEnabled() {
         load(DefaultConfiguration.class, "graphql.servlet.tracing-enabled=false", "graphql.servlet.actuator-metrics=true");
+
+        Assert.assertNotNull(this.getContext().getBean(MetricsInstrumentation.class));
+        Assert.assertNotNull(this.getContext().getBean(TracingNoResolversInstrumentation.class));
+    }
+
+    @Test
+    public void actuatorMetricsEnabled() {
+        load(DefaultConfiguration.class, "graphql.servlet.actuator-metrics=true");
 
         Assert.assertNotNull(this.getContext().getBean(MetricsInstrumentation.class));
         Assert.assertNotNull(this.getContext().getBean(TracingNoResolversInstrumentation.class));
@@ -103,8 +112,6 @@ public class GraphQLInstrumentationAutoConfigurationTest extends AbstractAutoCon
         this.getContext().getBean(TracingNoResolversInstrumentation.class);
         this.getContext().getBean(TracingInstrumentation.class);
     }
-
-
 
     @Test(expected = NoSuchBeanDefinitionException.class)
     public void actuatorMetricsDisabled() {


### PR DESCRIPTION
Before this fix TracingNoResolversInstrumentation is only provided if tracing-enabled is explicitly
set to false. Even if actuator-metric is set to to true, metrics wont be available because
metricsInstrumentation requires a TracingInstrumentation bean.