### PR TITLE
Don't reuse global headers for JSON parts

### DIFF
--- a/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/RequestFactory.java
+++ b/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/RequestFactory.java
@@ -19,8 +19,8 @@ class RequestFactory {
     static HttpEntity<Object> forMultipart(String query, String variables, HttpHeaders headers) {
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         LinkedMultiValueMap<String, Object> values = new LinkedMultiValueMap<>();
-        values.add("query", forJson(query, headers));
-        values.add("variables", forJson(variables, headers));
+        values.add("query", forJson(query, new HttpHeaders()));
+        values.add("variables", forJson(variables, new HttpHeaders()));
         return new HttpEntity<>(values, headers);
     }
 


### PR DESCRIPTION
This PR https://github.com/graphql-java-kickstart/graphql-spring-boot/pull/176 introduced a bug where the global `Content-Type` header for multipart requests was forced to `application/json;charset=UTF-8` instead of `multipart/form-data`. This makes the query parser fail.

This fixes #216 