### PR TITLE
Make it possible to disable google analytics in altair

### DIFF
--- a/altair-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/altair/boot/AltairController.java
+++ b/altair-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/altair/boot/AltairController.java
@@ -52,6 +52,9 @@ public class AltairController {
     @Value("${altair.cdn.version:2.1.4}")
     private String altairCdnVersion;
 
+    @Value("${altair.google-analytics.enabled:true}")
+    private boolean altairGoogleAnalyticsEnabled;
+
     @Autowired
     private Environment environment;
 
@@ -109,6 +112,7 @@ public class AltairController {
         replacements.put("graphqlEndpoint", graphqlEndpoint);
         replacements.put("subscriptionsEndpoint", subscriptionsEndpoint);
         replacements.put("pageTitle", pageTitle);
+        replacements.put("altairGoogleAnalyticsEnabled", Boolean.toString(altairGoogleAnalyticsEnabled));
         replacements.put("pageFavicon", getResourceUrl("favicon.ico", "favicon.ico"));
         replacements.put("altairBaseUrl", getResourceUrl(String.join(staticBasePath, "/vendor/altair/"),
                 joinJsUnpkgPath(ALTAIR, altairCdnVersion, "build/dist/")));

--- a/altair-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/altair-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -46,6 +46,11 @@
       "type": "java.lang.String"
     },
     {
+      "name": "altair.google-analytics.enabled",
+      "defaultValue": true,
+      "type": "java.lang.Boolean"
+    },
+    {
       "name": "altair.props.resources.defaultQuery",
       "defaultValue": null,
       "type": "java.lang.String"

--- a/altair-spring-boot-autoconfigure/src/main/resources/altair.html
+++ b/altair-spring-boot-autoconfigure/src/main/resources/altair.html
@@ -21,6 +21,7 @@
     window.__ALTAIR_INITIAL_VARIABLES__ = `${properties.variables}`;
     window.__ALTAIR_INITIAL_HEADERS__ = JSON.parse(`${headers}`);
 
+    window['ga-disable-UA-41432833-6'] = (`${altairGoogleAnalyticsEnabled}` === "false");
 </script>
 <app-root>
     <style>


### PR DESCRIPTION
Added the property `altair.google-analytics.enabled`. When set to false, this will disable google analytics in altair. By default this is set to true.