### PR TITLE
Enable all schema parser options to be set via properties

### DIFF
--- a/graphql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphql/boot/GraphQLToolsProperties.java
+++ b/graphql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphql/boot/GraphQLToolsProperties.java
@@ -9,6 +9,8 @@ import org.springframework.context.annotation.Configuration;
 class GraphQLToolsProperties {
 
     private String schemaLocationPattern = "**/*.graphqls";
+    /** @deprecated Set graphql.tools.schema-parser-options.introspection-enabled instead */
+    @Deprecated
     private boolean introspectionEnabled = true;
     private boolean useDefaultObjectmapper = true;
 


### PR DESCRIPTION
I've made some changes to allow SchemaParserOptions to be configured via properties.

Main motivation is so that you can set `allowUnimplementedResolvers=true` for tests. 

If you'd like me to change anything else please let me know,