### PR TITLE
Override CSRF header for existing tabs on page load

### DIFF
--- a/playground-spring-boot-autoconfigure/src/main/resources/templates/playground.html
+++ b/playground-spring-boot-autoconfigure/src/main/resources/templates/playground.html
@@ -28,7 +28,12 @@
         properties.headers[csrf.headerName] = csrf.token;
     }
     if (properties.tabs) {
-        properties.tabs.forEach(tab => tab.headers = Object.assign({}, properties.headers || {}, tab.headers || {}));
+        properties.tabs.forEach(tab => {
+            tab.headers = Object.assign({}, properties.headers || {}, tab.headers || {});
+            if (csrf) {
+                tab.headers[csrf.headerName] = csrf.token;
+            }
+        });
     }
     properties.setTitle = false;
     window.addEventListener('load', function (event) {


### PR DESCRIPTION
Upon deploying in our environment I noticed that existing tabs would get the correct CSRF header on initial load but after refreshing/etc. with sessions only the new tab was using the correct CSRF header.