### PR TITLE
feat: added method to type-safely get List of objects

### DIFF
--- a/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLResponse.java
+++ b/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLResponse.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 
 public class GraphQLResponse {
@@ -35,6 +36,11 @@ public class GraphQLResponse {
 
     public <T> T get(String path, Class<T> type) {
         return context.read(path, type);
+    }
+
+    public <T> List<T> getList(String path, Class<T> type) {
+        final List<?> raw = context.read(path, List.class);
+        return mapper.convertValue(raw, mapper.getTypeFactory().constructCollectionType(List.class, type));
     }
 
     public ReadContext context() {


### PR DESCRIPTION
Currently there is no simple way to get a type-safe list from `GraphQLResponse`. `get("$.data.fooBars", List.class)` would return a list of `LinkedHashMap`s, requiring an additional step to convert these to a list of POJOs.

This small new method is intended to simplify this repetitive step.