### PR TITLE
add support for testing with graphql fragments

### DIFF
--- a/example-graphql-tools/src/test/java/com/graphql/sample/boot/GraphQLToolsSampleApplicationTest.java
+++ b/example-graphql-tools/src/test/java/com/graphql/sample/boot/GraphQLToolsSampleApplicationTest.java
@@ -17,6 +17,9 @@ import static graphql.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RunWith(SpringRunner.class)
 @GraphQLTest
 public class GraphQLToolsSampleApplicationTest {
@@ -28,6 +31,16 @@ public class GraphQLToolsSampleApplicationTest {
     @Ignore
     public void get_comments() throws IOException {
         GraphQLResponse response = graphQLTestTemplate.postForResource("graphql/post-get-comments.graphql");
+        assertNotNull(response);
+        assertTrue(response.isOk());
+        assertEquals("1", response.get("$.data.post.id"));
+    }
+
+    @Test
+    public void get_comments_withFragments() throws IOException {
+        List<String> fragments = new ArrayList<>();
+        fragments.add("graphql/all-comment-fields-fragment.graphql");
+        GraphQLResponse response = graphQLTestTemplate.postForResource("graphql/post-get-comments-with-fragment.graphql", fragments);
         assertNotNull(response);
         assertTrue(response.isOk());
         assertEquals("1", response.get("$.data.post.id"));

--- a/example-graphql-tools/src/test/resources/graphql/all-comment-fields-fragment.graphql
+++ b/example-graphql-tools/src/test/resources/graphql/all-comment-fields-fragment.graphql
@@ -1,0 +1,4 @@
+fragment AllCommentFields on Comment {
+    id
+    description
+}

--- a/example-graphql-tools/src/test/resources/graphql/post-get-comments-with-fragment.graphql
+++ b/example-graphql-tools/src/test/resources/graphql/post-get-comments-with-fragment.graphql
@@ -1,0 +1,8 @@
+query {
+    post(id: "1") {
+        id
+        comments {
+            ...AllCommentFields
+        }
+    }
+}

--- a/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestTemplate.java
+++ b/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestTemplate.java
@@ -16,20 +16,23 @@ import org.springframework.util.StreamUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
-
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class GraphQLTestTemplate {
 
-    @Autowired private ResourceLoader resourceLoader;
-    @Autowired(required = false) private TestRestTemplate restTemplate;
-    @Value("${graphql.servlet.mapping:/graphql}") private String graphqlMapping;
+    @Autowired
+    private ResourceLoader resourceLoader;
+    @Autowired(required = false)
+    private TestRestTemplate restTemplate;
+    @Value("${graphql.servlet.mapping:/graphql}")
+    private String graphqlMapping;
 
     private ObjectMapper objectMapper = new ObjectMapper();
     private HttpHeaders headers = new HttpHeaders();
 
-    private String createJsonQuery(String graphql, ObjectNode variables) throws JsonProcessingException {
+    private String createJsonQuery(String graphql, ObjectNode variables)
+            throws JsonProcessingException {
 
         ObjectNode wrapper = objectMapper.createObjectNode();
         wrapper.put("query", graphql);
@@ -51,7 +54,7 @@ public class GraphQLTestTemplate {
     /**
      * Add an HTTP header that will be sent with each request this sends.
      *
-     * @param name  Name (key) of HTTP header to add.
+     * @param name Name (key) of HTTP header to add.
      * @param value Value of HTTP header to add.
      */
     public void addHeader(String name, String value) {
@@ -75,10 +78,11 @@ public class GraphQLTestTemplate {
     }
 
     /**
+     * @deprecated Use {@link #postForResource(String)} instead
+     *
      * @param graphqlResource path to the classpath resource containing the GraphQL query
      * @return GraphQLResponse containing the result of query execution
      * @throws IOException if the resource cannot be loaded from the classpath
-     * @deprecated Use {@link #postForResource(String)} instead
      */
     public GraphQLResponse perform(String graphqlResource) throws IOException {
         return postForResource(graphqlResource);


### PR DESCRIPTION
## Motivation

This PR is to meet a need discovered recently while writing tens of tests using the same return types, and discovering that the `GraphQLTestTemplate` doesn't support querying with fragments (or at least not obviously):
For example, given the following graphqls query resource files:

- `some-fragment.graphqls`
- `some-query-using-fragment.graphqls`

`graphQLTestTemplate.postForResource('graphql/some-query-using-fragment.graphqls')` will fail.

## Proposed Solution

This PR adds overloaded methods to `GraphQLTestTemplate#postForResource` and `GraphQLTestTemplate#perform`, so that the above scenario can be handled with:
```
graphQLTestTemplate.postForResource(
          'graphql/some-query-using-fragment.graphqls', 
          List.of(some-fragment.graphqls)
)
```
And can be applied to an arbitrary number of fragments.