### PR TITLE
Add support for GraphiQL in a reactive context

### DIFF
--- a/graphiql-spring-boot-autoconfigure/build.gradle
+++ b/graphiql-spring-boot-autoconfigure/build.gradle
@@ -23,6 +23,7 @@ dependencies{
     compile "org.apache.commons:commons-text:1.1"
     compileOnly "org.springframework.boot:spring-boot-starter-web:$LIB_SPRING_BOOT_VER"
     compileOnly "org.springframework.boot:spring-boot-starter-security:$LIB_SPRING_BOOT_VER"
+    compileOnly "io.projectreactor:reactor-core:3.3.0.RELEASE"
 
     testCompile "org.springframework.boot:spring-boot-starter-web:$LIB_SPRING_BOOT_VER"
     testCompile "org.springframework.boot:spring-boot-starter-test:$LIB_SPRING_BOOT_VER"

--- a/graphiql-spring-boot-autoconfigure/build.gradle
+++ b/graphiql-spring-boot-autoconfigure/build.gradle
@@ -27,6 +27,8 @@ dependencies{
 
     testCompile "org.springframework.boot:spring-boot-starter-web:$LIB_SPRING_BOOT_VER"
     testCompile "org.springframework.boot:spring-boot-starter-test:$LIB_SPRING_BOOT_VER"
+
+    testRuntime "org.springframework.boot:spring-boot-starter-webflux:$LIB_SPRING_BOOT_VER"
 }
 
 compileJava.dependsOn(processResources)

--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/GraphiQLAutoConfiguration.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/GraphiQLAutoConfiguration.java
@@ -1,6 +1,7 @@
 package com.oembedler.moon.graphiql.boot;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -8,19 +9,28 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.DispatcherServlet;
 
+import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type.SERVLET;
+import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type.REACTIVE;
+
 /**
  * @author Andrew Potter
+ * @author Ronny Bräunlich
  */
 @Configuration
-@ConditionalOnWebApplication
-@ConditionalOnClass(DispatcherServlet.class)
+@ConditionalOnProperty(value = "graphiql.enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(GraphiQLProperties.class)
 public class GraphiQLAutoConfiguration {
 
-    @Bean
-    @ConditionalOnProperty(value = "graphiql.enabled", havingValue = "true", matchIfMissing = true)
-    GraphiQLController graphiQLController() {
-        return new GraphiQLController();
+    @Bean(name = "graphiQLController")
+    @ConditionalOnWebApplication(type=SERVLET)
+    ServletGraphiQLController servletGraphiQLController() {
+        return new ServletGraphiQLController();
     }
 
+    @Bean(name = "graphiQLController")
+    @ConditionalOnMissingBean(ServletGraphiQLController.class)
+    @ConditionalOnWebApplication(type=REACTIVE)
+    ReactiveGraphiQLController reactiveGraphiQLController() {
+        return new ReactiveGraphiQLController();
+    }
 }

--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/ReactiveGraphiQLController.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/ReactiveGraphiQLController.java
@@ -35,7 +35,7 @@ public class ReactiveGraphiQLController extends GraphiQLController {
     super.onceConstructed();
   }
 
-  @RequestMapping(value = "${graphiql.mapping:/api}")
+  @RequestMapping(value = "${graphiql.mapping:/graphiql}")
   public Mono<Void> graphiql(ServerHttpRequest request, ServerHttpResponse response,
                              @PathVariable Map<String, String> params) {
     response.getHeaders().setContentType(MediaType.TEXT_HTML);

--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/ReactiveGraphiQLController.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/ReactiveGraphiQLController.java
@@ -1,0 +1,48 @@
+package com.oembedler.moon.graphiql.boot;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.StrSubstitutor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import reactor.core.publisher.Mono;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Controller
+public class ReactiveGraphiQLController extends GraphiQLController {
+
+  private DataBufferFactory dataBufferFactory = new DefaultDataBufferFactory();
+
+  @PostConstruct
+  public void onceConstructed() throws IOException {
+    super.onceConstructed();
+  }
+
+  @RequestMapping(value = "${graphiql.mapping:/api}")
+  public Mono<Void> graphiql(ServerHttpRequest request, ServerHttpResponse response,
+                             @PathVariable Map<String, String> params) {
+    response.getHeaders().setContentType(MediaType.TEXT_HTML);
+    Object csrf = request.getQueryParams().getFirst("_csrf");
+    return response.writeWith(Mono.just(request.getPath().contextPath().value())
+        .map(contextPath -> super.graphiql(contextPath, params, csrf))
+        .map(dataBufferFactory::wrap));
+  }
+
+}

--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/ServletGraphiQLController.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/ServletGraphiQLController.java
@@ -1,0 +1,50 @@
+package com.oembedler.moon.graphiql.boot;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.StrSubstitutor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * @author Andrew Potter
+ */
+@Slf4j
+@Controller
+public class ServletGraphiQLController extends GraphiQLController{
+
+    @PostConstruct
+    public void onceConstructed() throws IOException {
+        super.onceConstructed();
+    }
+
+    @GetMapping(value = "${graphiql.mapping:/graphiql}")
+    public void graphiql(HttpServletRequest request, HttpServletResponse response,
+                         @PathVariable Map<String, String> params) throws IOException {
+        response.setContentType("text/html; charset=UTF-8");
+        Object csrf = request.getAttribute("_csrf");
+        byte[] graphiqlBytes = super.graphiql(request.getContextPath(), params, csrf);
+        response.getOutputStream().write(graphiqlBytes);
+    }
+
+}

--- a/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/ServletGraphiQLController.java
+++ b/graphiql-spring-boot-autoconfigure/src/main/java/com/oembedler/moon/graphiql/boot/ServletGraphiQLController.java
@@ -1,30 +1,15 @@
 package com.oembedler.moon.graphiql.boot;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.text.StrSubstitutor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.http.MediaType;
-import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.Charset;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 /**
  * @author Andrew Potter

--- a/graphiql-spring-boot-autoconfigure/src/test/java/com/oembedler/moon/graphiql/boot/ReactiveGraphiQLControllerTest.java
+++ b/graphiql-spring-boot-autoconfigure/src/test/java/com/oembedler/moon/graphiql/boot/ReactiveGraphiQLControllerTest.java
@@ -1,0 +1,35 @@
+package com.oembedler.moon.graphiql.boot;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@RunWith(SpringRunner.class)
+@WebFluxTest
+public class ReactiveGraphiQLControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    public void shouldBeAbleToAccessGraphiQL() {
+      webTestClient.get()
+          .uri("/graphiql")
+          .exchange()
+          .expectStatus().is2xxSuccessful()
+          .expectHeader().contentType(MediaType.TEXT_HTML);
+    }
+
+    @SpringBootConfiguration
+    @TestPropertySource(properties = "graphiql.enabled=true")
+    @Import(GraphiQLAutoConfiguration.class)
+    public static class ReactiveTestApplication {
+    }
+}

--- a/graphiql-spring-boot-autoconfigure/src/test/java/com/oembedler/moon/graphiql/boot/ServletGraphiQLControllerTest.java
+++ b/graphiql-spring-boot-autoconfigure/src/test/java/com/oembedler/moon/graphiql/boot/ServletGraphiQLControllerTest.java
@@ -1,0 +1,36 @@
+package com.oembedler.moon.graphiql.boot;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest
+public class ServletGraphiQLControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void shouldBeAbleToAccessGraphiQL() throws Exception {
+      mockMvc.perform(get("/graphiql"))
+          .andExpect(status().is2xxSuccessful())
+          .andExpect(content().contentType("text/html; charset=UTF-8"));
+    }
+
+    @SpringBootConfiguration
+    @TestPropertySource(properties = "graphiql.enabled=true")
+    @Import(GraphiQLAutoConfiguration.class)
+    public static class ServletTestApplication {
+    }
+}


### PR DESCRIPTION
Basically, I need GraphiQL when using Webflux and not MVC. Therefore, I tried to reuse as much code as possible and abstract away the specifics. I'm not completely sure how to test the two versions (servlet and reactive) separately. I was hoping somebody here might have an idea.