### PR TITLE
feat: improvements for GraphQL response testing facilities

### DIFF
--- a/graphql-spring-boot-test/build.gradle
+++ b/graphql-spring-boot-test/build.gradle
@@ -19,11 +19,16 @@
 dependencies {
     compile("org.springframework:spring-web:$LIB_SPRING_CORE_VER")
     compile("org.springframework.boot:spring-boot-starter-test:$LIB_SPRING_BOOT_VER")
-    compile("com.fasterxml.jackson.core:jackson-databind:2.5.4")
-    compile("com.jayway.jsonpath:json-path:2.3.0")
+    compile("com.fasterxml.jackson.core:jackson-databind:2.10.2")
+    compile("com.jayway.jsonpath:json-path:2.4.0")
     compileOnly("com.graphql-java:graphql-java:$LIB_GRAPHQL_JAVA_VER")
     compileOnly("com.graphql-java-kickstart:graphql-java-servlet:$LIB_GRAPHQL_SERVLET_VER")
+    testImplementation("org.springframework.boot:spring-boot-starter-web:$LIB_SPRING_BOOT_VER")
 }
 repositories {
     mavenCentral()
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLResponse.java
+++ b/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLResponse.java
@@ -13,13 +13,13 @@ import java.util.Objects;
 
 public class GraphQLResponse {
 
-    private ResponseEntity<String> responseEntity;
-    private ObjectMapper mapper;
-    private ReadContext context;
+    private final ResponseEntity<String> responseEntity;
+    private final ObjectMapper mapper;
+    private final ReadContext context;
 
-    public GraphQLResponse(ResponseEntity<String> responseEntity) {
+    public GraphQLResponse(ResponseEntity<String> responseEntity, ObjectMapper objectMapper) {
         this.responseEntity = Objects.requireNonNull(responseEntity);
-        this.mapper = new ObjectMapper();
+        this.mapper = Objects.requireNonNull(objectMapper);
 
         Objects.requireNonNull(responseEntity.getBody(),
                 () -> "Body is empty with status " + responseEntity.getStatusCodeValue());
@@ -31,11 +31,11 @@ public class GraphQLResponse {
     }
 
     public String get(String path) {
-        return context.read(path);
+        return get(path, String.class);
     }
 
     public <T> T get(String path, Class<T> type) {
-        return context.read(path, type);
+        return mapper.convertValue(context.read(path, Object.class), type);
     }
 
     public <T> List<T> getList(String path, Class<T> type) {

--- a/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestTemplate.java
+++ b/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestTemplate.java
@@ -27,8 +27,9 @@ public class GraphQLTestTemplate {
     private TestRestTemplate restTemplate;
     @Value("${graphql.servlet.mapping:/graphql}")
     private String graphqlMapping;
+    @Autowired
+    private ObjectMapper objectMapper;
 
-    private ObjectMapper objectMapper = new ObjectMapper();
     private HttpHeaders headers = new HttpHeaders();
 
     private String createJsonQuery(String graphql, ObjectNode variables)
@@ -138,7 +139,7 @@ public class GraphQLTestTemplate {
 
     private GraphQLResponse postRequest(HttpEntity<Object> request) {
         ResponseEntity<String> response = restTemplate.exchange(graphqlMapping, HttpMethod.POST, request, String.class);
-        return new GraphQLResponse(response);
+        return new GraphQLResponse(response, objectMapper);
     }
 
 }

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLResponseTest.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLResponseTest.java
@@ -1,0 +1,122 @@
+package com.graphql.spring.boot.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = TestApplication.class)
+public class GraphQLResponseTest {
+
+    private static final String DATA_PATH = "$.data.test";
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static Stream<Arguments> testGetStringArguments() {
+        return Stream.of(
+            Arguments.of("{\"data\": {\"test\": 2}}", "2"),
+            Arguments.of("{\"data\": {\"test\": \"2\"}}", "2"),
+            Arguments.of("{\"data\": {\"test\": \"2020-02-23\"}}", "2020-02-23")
+        );
+    }
+
+    private static Stream<Arguments> testGetArguments() {
+        return Stream.of(
+            Arguments.of("{\"data\": {\"test\": \"2\"}}", Integer.class, 2),
+            Arguments.of("{\"data\": {\"test\": \"2\"}}", String.class, "2"),
+            Arguments.of("{\"data\": {\"test\": \"2\"}}", BigDecimal.class, new BigDecimal("2")),
+            Arguments.of("{\"data\": {\"test\": \"2020-02-23\"}}", LocalDate.class, LocalDate.parse("2020-02-23")),
+            Arguments.of("{\"data\": {\"test\": {\"foo\": \"fizzBuzz\", \"bar\": 13.8 }}}", FooBar.class,
+                new FooBar("fizzBuzz", new BigDecimal("13.8")))
+        );
+    }
+
+    private static Stream<Arguments> testGetListArguments() {
+        return Stream.of(
+            Arguments.of("{\"data\": {\"test\": [\"2\", \"1\"]}}", Integer.class, Arrays.asList(2, 1)),
+            Arguments.of("{\"data\": {\"test\": [\"2\", \"1\"]}}", String.class, Arrays.asList("2", "1")),
+            Arguments.of("{\"data\": {\"test\": [\"2\", \"1\"]}}", BigDecimal.class,
+                Arrays.asList(new BigDecimal("2"), new BigDecimal("1"))),
+            Arguments.of("{\"data\": {\"test\": [\"2020-02-23\", \"2020-02-24\"]}}", LocalDate.class,
+                Arrays.asList(LocalDate.parse("2020-02-23"), LocalDate.parse("2020-02-24"))),
+            Arguments.of("{\"data\":{\"test\":[{\"foo\":\"fizz\",\"bar\":1.23},{\"foo\":\"buzz\",\"bar\":32.12}]}}",
+                FooBar.class,
+                Arrays.asList(
+                    new FooBar("fizz", new BigDecimal("1.23")),
+                    new FooBar("buzz", new BigDecimal("32.12"))
+                )
+            )
+        );
+    }
+
+    @DisplayName("Should get the JSON node's value as a String.")
+    @ParameterizedTest
+    @MethodSource("testGetStringArguments")
+    public void testGetString(
+        final String bodyString,
+        final String expected
+    ) {
+        //GIVEN
+        final GraphQLResponse graphQLResponse = new GraphQLResponse(ResponseEntity.ok(bodyString), objectMapper);
+        //WHEN
+        final String actual = graphQLResponse.get(DATA_PATH);
+        //THEN
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @DisplayName("Should get the JSON node's value as an instance of a specified class.")
+    @ParameterizedTest
+    @MethodSource("testGetArguments")
+    public <T> void testGet(
+        final String bodyString,
+        final Class<T> clazz,
+        final T expected
+    ) {
+        //GIVEN
+        final GraphQLResponse graphQLResponse = new GraphQLResponse(ResponseEntity.ok(bodyString), objectMapper);
+        //WHEN
+        final T actual = graphQLResponse.get(DATA_PATH, clazz);
+        //THEN
+        assertThat(actual).isInstanceOf(clazz).isEqualTo(expected);
+    }
+
+    @DisplayName("Should get the JSON node's value as a List.")
+    @ParameterizedTest
+    @MethodSource("testGetListArguments")
+    public <T> void testGetList(
+        final String bodyString,
+        final Class<T> clazz,
+        final List<T> expected
+    ) {
+        //GIVEN
+        final GraphQLResponse graphQLResponse = new GraphQLResponse(ResponseEntity.ok(bodyString), objectMapper);
+        //WHEN
+        final List<T> actual = graphQLResponse.getList(DATA_PATH, clazz);
+        //THEN
+        assertThat(actual).containsExactlyElementsOf(expected);
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    private static class FooBar {
+        private String foo;
+        private BigDecimal bar;
+    }
+}

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/TestApplication.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/TestApplication.java
@@ -1,0 +1,12 @@
+package com.graphql.spring.boot.test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TestApplication.class, args);
+    }
+}


### PR DESCRIPTION
GraphQLResponse and GraphQLTestTemplate now use the ObjectMapper bean
from the tested application.

The `get` methods now use the object mapper to convert the variable to
the specified type. Formerly they used vanilla JsonPath library methods
that may produce unexpected results. E. g. given the following response
body:

`{"data": {"test": 2}}`

a call to `get("$.data.test")` would result in an
`ClassCastException`, which is usually not the desired behaviour.

It was also very restrictive on data types: only "native" JSON types
were supported (e. g. int, boolean, String).

Furthermore it seems to have issues with more complex classes, like
POJOs and may return `null`.

Several test cases were added to ensure correct behaviour. Some of
these tests would fail with the previous version.