### PR TITLE
docs: update version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,19 +80,19 @@ repositories {
 }
 
 dependencies {
-  compile 'com.graphql-java-kickstart:graphql-spring-boot-starter:6.0.0'
+  compile 'com.graphql-java-kickstart:graphql-spring-boot-starter:6.0.1'
   
   // to embed Altair tool
-  runtime 'com.graphql-java-kickstart:altair-spring-boot-starter:6.0.0'
+  runtime 'com.graphql-java-kickstart:altair-spring-boot-starter:6.0.1'
 
   // to embed GraphiQL tool
-  runtime 'com.graphql-java-kickstart:graphiql-spring-boot-starter:6.0.0'
+  runtime 'com.graphql-java-kickstart:graphiql-spring-boot-starter:6.0.1'
 
   // to embed Voyager tool
-  runtime 'com.graphql-java-kickstart:voyager-spring-boot-starter:6.0.0'
+  runtime 'com.graphql-java-kickstart:voyager-spring-boot-starter:6.0.1'
   
   // testing facilities
-  testCompile 'com.graphql-java-kickstart:graphql-spring-boot-starter-test:6.0.0'
+  testCompile 'com.graphql-java-kickstart:graphql-spring-boot-starter-test:6.0.1'
 }
 ```
 
@@ -101,14 +101,14 @@ Maven:
 <dependency>
     <groupId>com.graphql-java-kickstart</groupId>
     <artifactId>graphql-spring-boot-starter</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1</version>
 </dependency>
 
 <!-- to embed Altair tool -->
 <dependency>
     <groupId>com.graphql-java-kickstart</groupId>
     <artifactId>altair-spring-boot-starter</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1</version>
     <scope>runtime</scope>
 </dependency>
 
@@ -116,7 +116,7 @@ Maven:
 <dependency>
     <groupId>com.graphql-java-kickstart</groupId>
     <artifactId>graphiql-spring-boot-starter</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1</version>
     <scope>runtime</scope>
 </dependency>
 
@@ -124,7 +124,7 @@ Maven:
 <dependency>
     <groupId>com.graphql-java-kickstart</groupId>
     <artifactId>voyager-spring-boot-starter</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1</version>
     <scope>runtime</scope>
 </dependency>
 
@@ -132,7 +132,7 @@ Maven:
 <dependency>
     <groupId>com.graphql-java-kickstart</groupId>
     <artifactId>graphql-spring-boot-starter-test</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1</version>
     <scope>test</scope>
 </dependency>
 


### PR DESCRIPTION
Current verison refers to 6.0.0 that has the content length issue.