### PR TITLE
fix: add missing auto-complete support for graphql.playground.enabled

### DIFF
--- a/playground-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/playground-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -4,6 +4,11 @@
       "name": "graphql.playground.mapping",
       "defaultValue": "/playground",
       "type": "java.lang.String"
+    },
+    {
+      "name": "graphql.playground.enabled",
+      "defaultValue": true,
+      "type": "java.lang.Boolean"
     }
   ]
 }


### PR DESCRIPTION
This property was missing from additional spring configuration
metadata.