### PR TITLE
fix Duplicate EnableAutoConfiguration Key

### DIFF
--- a/voyager-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/voyager-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=graphql.kickstart.voyager.boot.VoyagerAutoConfiguration
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=graphql.kickstart.voyager.boot.ReactiveVoyagerAutoConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  graphql.kickstart.voyager.boot.VoyagerAutoConfiguration,\
+  graphql.kickstart.voyager.boot.ReactiveVoyagerAutoConfiguration
 


### PR DESCRIPTION
link https://github.com/graphql-java-kickstart/graphql-spring-boot/issues/374

`org.springframework.boot.autoconfigure.EnableAutoConfiguration` in `spring.factories` is **Duplicate property key** and could not be work.

