### PR TITLE
Add facilities to test subscriptions

### DIFF
--- a/graphql-spring-boot-test-autoconfigure/build.gradle
+++ b/graphql-spring-boot-test-autoconfigure/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("com.graphql-java-kickstart:graphql-java-tools:$LIB_GRAPHQL_JAVA_TOOLS_VER")
+
+    testImplementation "io.reactivex.rxjava2:rxjava"
 }
 
 compileJava.dependsOn(processResources)

--- a/graphql-spring-boot-test-autoconfigure/src/main/java/com/graphql/spring/boot/test/GraphQLTestAutoConfiguration.java
+++ b/graphql-spring-boot-test-autoconfigure/src/main/java/com/graphql/spring/boot/test/GraphQLTestAutoConfiguration.java
@@ -1,10 +1,13 @@
 package com.graphql.spring.boot.test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 @Configuration
 @ConditionalOnWebApplication
@@ -15,6 +18,17 @@ public class GraphQLTestAutoConfiguration {
     @ConditionalOnMissingBean
     public GraphQLTestTemplate graphQLTestUtils() {
         return new GraphQLTestTemplate();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public GraphQLTestSubscription graphQLTestSubscription(
+        final Environment environment,
+        final ObjectMapper objectMapper,
+        @Value("${graphql.servlet.subscriptions.websocket.path:subscriptions}")
+        final String subscriptionPath
+    ) {
+        return new GraphQLTestSubscription(environment, objectMapper, subscriptionPath);
     }
 
 }

--- a/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/GraphQLTestAutoConfigurationTestBase.java
+++ b/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/GraphQLTestAutoConfigurationTestBase.java
@@ -1,0 +1,40 @@
+package com.graphql.spring.boot.test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class GraphQLTestAutoConfigurationTestBase {
+
+    static final String FOO = "foo";
+
+    @Autowired
+    ApplicationContext applicationContext;
+
+    void assertThatTestSubscriptionWorksCorrectly() {
+        // GIVEN
+        final GraphQLTestSubscription graphQLTestSubscription
+            = applicationContext.getBean(GraphQLTestSubscription.class);
+        // WHEN
+        final GraphQLResponse graphQLResponse
+            = graphQLTestSubscription.start("test-subscription.graphql").awaitAndGetNextResponse(1000);
+        // THEN
+        assertThat(graphQLResponse.get("$.data.testSubscription")).isEqualTo(FOO);
+    }
+
+    void assertThatTestTemplateAutoConfigurationWorksCorrectly() throws IOException {
+        // GIVEN
+        final GraphQLTestTemplate graphQLTestTemplate
+            = applicationContext.getBean(GraphQLTestTemplate.class);
+        // WHEN
+        final GraphQLResponse graphQLResponse
+            = graphQLTestTemplate.postForResource("test-query.graphql");
+        // THEN
+        assertThat(graphQLResponse.get("$.data.testQuery")).isEqualTo(FOO);
+    }
+}

--- a/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionAutoConfigurationCustomConfigTest.java
+++ b/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionAutoConfigurationCustomConfigTest.java
@@ -1,0 +1,23 @@
+package com.graphql.spring.boot.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles({"test", "custom-subscription-path"})
+@DisplayName("Testing the auto-configuration of the GraphQLTestSubscription bean / custom subscription endpoint.")
+public class GraphQLTestSubscriptionAutoConfigurationCustomConfigTest extends GraphQLTestAutoConfigurationTestBase {
+
+    @Test
+    @DisplayName("Should provide a GraphQLTestTemplate bean.")
+    void shouldProvideGraphQLTestSubscriptionBean() {
+        assertThatTestSubscriptionWorksCorrectly();
+        assertThat(ReflectionTestUtils.getField(applicationContext.getBean(GraphQLTestSubscription.class),
+            "subscriptionPath"))
+            .as("Should use the configured subscription path.")
+            .isEqualTo("/myCustomPath");
+    }
+}

--- a/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionAutoConfigurationDefaultConfigTest.java
+++ b/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionAutoConfigurationDefaultConfigTest.java
@@ -1,0 +1,14 @@
+package com.graphql.spring.boot.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Testing the auto-configuration of the GraphQLTestSubscription bean / default settings.")
+public class GraphQLTestSubscriptionAutoConfigurationDefaultConfigTest extends GraphQLTestAutoConfigurationTestBase {
+
+    @Test
+    @DisplayName("Should provide a GraphQLTestTemplate bean.")
+    void shouldProvideGraphQLTestSubscriptionBean() {
+        assertThatTestSubscriptionWorksCorrectly();
+    }
+}

--- a/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/GraphQLTestTemplateAutoConfigurationCustomConfigTest.java
+++ b/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/GraphQLTestTemplateAutoConfigurationCustomConfigTest.java
@@ -1,0 +1,25 @@
+package com.graphql.spring.boot.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles({"test", "custom-servlet-mapping"})
+@DisplayName("Testing auto-configuration of the GraphQLTestTemplate bean / custom servlet endpoint.")
+public class GraphQLTestTemplateAutoConfigurationCustomConfigTest extends GraphQLTestAutoConfigurationTestBase {
+
+    @Test
+    @DisplayName("GraphQLTestTemplate bean should work properly.")
+    void shouldProvideGraphQLTestTemplateBean() throws IOException {
+        assertThatTestTemplateAutoConfigurationWorksCorrectly();
+        assertThat(ReflectionTestUtils.getField(applicationContext.getBean(GraphQLTestTemplate.class),
+            "graphqlMapping"))
+            .as("Should use the configured servlet path.")
+            .isEqualTo("/myCustomGraphQLEndpoint");
+    }
+}

--- a/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/GraphQLTestTemplateAutoConfigurationDefaultConfigTest.java
+++ b/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/GraphQLTestTemplateAutoConfigurationDefaultConfigTest.java
@@ -1,0 +1,16 @@
+package com.graphql.spring.boot.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+@DisplayName("Testing auto-configuration of the GraphQLTestTemplate bean / default servlet endpoint.")
+public class GraphQLTestTemplateAutoConfigurationDefaultConfigTest extends GraphQLTestAutoConfigurationTestBase {
+
+    @Test
+    @DisplayName("GraphQLTestTemplate bean should work properly.")
+    void shouldProvideGraphQLTestTemplateBean() throws IOException {
+        assertThatTestTemplateAutoConfigurationWorksCorrectly();
+    }
+}

--- a/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/TestApplication.java
+++ b/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/TestApplication.java
@@ -1,0 +1,13 @@
+package com.graphql.spring.boot.test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TestApplication.class, args);
+    }
+}
+

--- a/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/beans/TestQuery.java
+++ b/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/beans/TestQuery.java
@@ -1,0 +1,12 @@
+package com.graphql.spring.boot.test.beans;
+
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TestQuery implements GraphQLQueryResolver {
+
+    public String testQuery() {
+        return "foo";
+    }
+}

--- a/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/beans/TestSubscription.java
+++ b/graphql-spring-boot-test-autoconfigure/src/test/java/com/graphql/spring/boot/test/beans/TestSubscription.java
@@ -1,0 +1,13 @@
+package com.graphql.spring.boot.test.beans;
+
+import graphql.kickstart.tools.GraphQLSubscriptionResolver;
+import io.reactivex.Flowable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TestSubscription implements GraphQLSubscriptionResolver {
+
+    public Flowable<String> testSubscription() {
+        return Flowable.just("foo");
+    }
+}

--- a/graphql-spring-boot-test-autoconfigure/src/test/resources/application-custom-servlet-mapping.yaml
+++ b/graphql-spring-boot-test-autoconfigure/src/test/resources/application-custom-servlet-mapping.yaml
@@ -1,0 +1,1 @@
+graphql.servlet.mapping: /myCustomGraphQLEndpoint

--- a/graphql-spring-boot-test-autoconfigure/src/test/resources/application-custom-subscription-path.yaml
+++ b/graphql-spring-boot-test-autoconfigure/src/test/resources/application-custom-subscription-path.yaml
@@ -1,0 +1,1 @@
+graphql.servlet.subscriptions.websocket.path: /myCustomPath

--- a/graphql-spring-boot-test-autoconfigure/src/test/resources/application.yaml
+++ b/graphql-spring-boot-test-autoconfigure/src/test/resources/application.yaml
@@ -1,0 +1,3 @@
+logging.level:
+  graphql.servlet: debug
+  com.graphql.spring.boot.test: debug

--- a/graphql-spring-boot-test-autoconfigure/src/test/resources/schema.graphqls
+++ b/graphql-spring-boot-test-autoconfigure/src/test/resources/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+    testQuery: String!
+}
+
+type Subscription {
+    testSubscription: String!
+}

--- a/graphql-spring-boot-test-autoconfigure/src/test/resources/test-query.graphql
+++ b/graphql-spring-boot-test-autoconfigure/src/test/resources/test-query.graphql
@@ -1,0 +1,3 @@
+query {
+    testQuery
+}

--- a/graphql-spring-boot-test-autoconfigure/src/test/resources/test-subscription.graphql
+++ b/graphql-spring-boot-test-autoconfigure/src/test/resources/test-subscription.graphql
@@ -1,0 +1,3 @@
+subscription {
+    testSubscription
+}

--- a/graphql-spring-boot-test/build.gradle
+++ b/graphql-spring-boot-test/build.gradle
@@ -24,4 +24,6 @@ dependencies {
     compileOnly("com.graphql-java:graphql-java:$LIB_GRAPHQL_JAVA_VER")
     compileOnly("com.graphql-java-kickstart:graphql-java-servlet:$LIB_GRAPHQL_SERVLET_VER")
     testImplementation("org.springframework.boot:spring-boot-starter-web")
+    testImplementation project(":graphql-spring-boot-starter")
+    testImplementation "io.reactivex.rxjava2:rxjava"
 }

--- a/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestSubscription.java
+++ b/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestSubscription.java
@@ -1,0 +1,415 @@
+package com.graphql.spring.boot.test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.util.ResourceUtils;
+
+import javax.websocket.ClientEndpointConfig;
+import javax.websocket.ContainerProvider;
+import javax.websocket.Endpoint;
+import javax.websocket.EndpointConfig;
+import javax.websocket.MessageHandler;
+import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Helper object to test GraphQL subscriptions.
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class GraphQLTestSubscription {
+
+    private static final int SLEEP_INTERVAL_MS = 100;
+    private static final AtomicInteger ID_COUNTER = new AtomicInteger(1);
+
+    @Getter
+    private Session session;
+
+    @Getter
+    private boolean initialized = false;
+    @Getter
+    private boolean acknowledged = false;
+    @Getter
+    private boolean started = false;
+    @Getter
+    private boolean stopped = false;
+
+    private final Environment environment;
+    private final ObjectMapper objectMapper;
+    private final String subscriptionPath;
+
+    private final Queue<GraphQLResponse> responses = new ConcurrentLinkedQueue<>();
+    private int id = ID_COUNTER.getAndIncrement();
+
+    /**
+     * Sends the "connection_init" message to the GraphQL server without a payload.
+     * @return self reference
+     */
+    public GraphQLTestSubscription init() {
+        init(null);
+        return this;
+    }
+
+    /**
+     * Sends the "connection_init" message to the GraphQL server.
+     * @param payload The payload of the connection_init message. May be null, if not needed.
+     * @return self reference
+     */
+    public GraphQLTestSubscription init(@Nullable final Object payload) {
+        if (initialized) {
+            fail("Subscription already initialized.");
+        }
+        try {
+            initClient();
+        } catch (Exception e) {
+            fail("Could not initialize test subscription client. No subscription defined?", e);
+        }
+        final ObjectNode message = objectMapper.createObjectNode();
+        message.put("type", "connection_init");
+        message.set("payload", getFinalPayload(payload));
+        sendMessage(message);
+        initialized = true;
+        return this;
+    }
+
+    /**
+     * Sends the "start" message to the GraphQL server.
+     * @param graphQLResource the GraphQL resource, which contains the query for the subscription start payload. The
+     *                        start message will be sent without variables.
+     * @return self reference
+     */
+    public GraphQLTestSubscription start(@NonNull final String graphQLResource) {
+        start(graphQLResource, null);
+        return this;
+    }
+
+    /**
+     * Sends the "start" message to the GraphQL Subscription.
+     * @param graphGLResource the GraphQL resource, which contains the query for the subscription start payload.
+     * @param variables the variables needed for the query to be evaluated.
+     * @return self reference
+     */
+    public GraphQLTestSubscription start(@NonNull final String graphGLResource, @Nullable final Object variables) {
+        if (!initialized) {
+            init();
+        }
+        if (started) {
+            fail("Start message already sent. To start a new subscription, please call reset first.");
+        }
+        started = true;
+        ObjectNode payload = objectMapper.createObjectNode();
+        payload.put("query", loadQuery(graphGLResource));
+        payload.set("variables", getFinalPayload(variables));
+        ObjectNode message = objectMapper.createObjectNode();
+        message.put("type", "start");
+        message.put("id", id);
+        message.set("payload", payload);
+        sendMessage(message);
+        return this;
+    }
+
+    /**
+     * Sends the "stop" message to the server.
+     * @return self reference
+     */
+    public GraphQLTestSubscription stop() {
+        if (!started) {
+            fail("Subscription not yet started.");
+        }
+        if (stopped) {
+            fail("Subscription already stopped.");
+        }
+        final ObjectNode message = objectMapper.createObjectNode();
+        message.put("type", "stop");
+        message.put("id", id);
+        sendMessage(message);
+        stopped = true;
+        try {
+            session.close();
+            session = null;
+        } catch (IOException e) {
+            fail("Could not close web socket session", e);
+        }
+        log.debug("Subscription stopped.");
+        return this;
+    }
+
+    /**
+     * Stops (if needed) and resets this instance. This should be called in the "afterEach" method of the test class, to
+     * ensure that the bean is reusable between tests.
+     */
+    public void reset() {
+        if (initialized && !stopped) {
+            stop();
+        }
+        if (stopped) {
+            id = ID_COUNTER.getAndIncrement();
+        }
+        initialized = false;
+        started = false;
+        stopped = false;
+        acknowledged = false;
+        responses.clear();
+    }
+
+    /**
+     * Awaits and returns the next response received from the subscription. The subscription will be stopped after
+     * receiving the message (or timeout).
+     * @param timeout timeout in milliseconds. Test will fail if no message received from the subscription until
+     *                the timeout expires.
+     * @return The received response.
+     */
+    public GraphQLResponse awaitAndGetNextResponse(final int timeout) {
+        return awaitAndGetNextResponses(timeout, 1, true).get(0);
+    }
+
+    /**
+     * Awaits and returns the next response received from the subscription.
+     * @param timeout timeout in milliseconds. Test will fail if no message received from the subscription until
+     *                the timeout expires.
+     * @param stopAfter if true, the subscription will be stopped after the message was received (or timeout).
+     * @return The received response.
+     */
+    public GraphQLResponse awaitAndGetNextResponse(final int timeout, final boolean stopAfter) {
+        return awaitAndGetNextResponses(timeout, 1, stopAfter).get(0);
+    }
+
+    /**
+     * Waits a specified amount time and returns all responses received during that time. This method does not have any
+     * expectation regarding the number of messages. The subscription will be stopped after the time elapsed.
+     * @param timeToWait the time to wait, in milliseconds
+     * @return the list of responses received during that time.
+     */
+    public List<GraphQLResponse> awaitAndGetAllResponses(final int timeToWait) {
+        return awaitAndGetNextResponses(timeToWait, -1, true);
+    }
+
+    /**
+     * Waits a specified amount time and returns all responses received during that time. This method does not have any
+     * expectation regarding the number of messages.
+     * @param timeToWait the time to wait, in milliseconds
+     * @param stopAfter if true, the subscription will be stopped after the time elapsed.
+     * @return the list of responses received during that time.
+     */
+    public List<GraphQLResponse> awaitAndGetAllResponses(final int timeToWait, final boolean stopAfter) {
+        return awaitAndGetNextResponses(timeToWait, -1, stopAfter);
+    }
+
+    /**
+     * Awaits and returns the specified number of responses. The subscription will be stopped after receiving the
+     * messages (or timeout).
+     * @param timeout timeout in milliseconds. Test will fail if the expected number of responses is not received.
+     * @param numExpectedResponses the number of expected responses. If negative, the method will wait the timeout
+     *                             and return all responses received during that time. In this case, no assertion is
+     *                             made regarding the number of responses, and the returned list may be empty. If
+     *                             zero, it is expected that no responses are sent during the timeout period.
+     * @return The list containing the expected number of responses. The list contains the responses in the order they
+     * were received. If more responses are received than minimally expected, {@link #getRemainingResponses()}  can
+     * be used to retrieved them.
+     */
+    public List<GraphQLResponse> awaitAndGetNextResponses(
+        final int timeout,
+        final int numExpectedResponses
+    ) {
+        return awaitAndGetNextResponses(timeout, numExpectedResponses, true);
+    }
+
+    /**
+     * Awaits and returns the specified number of responses.
+     * @param timeout timeout in milliseconds. Test will fail if the expected number of responses is not received.
+     * @param numExpectedResponses the number of expected responses. If negative, the method will wait the timeout
+     *                             and return all responses received during that time. In this case, no assertion is
+     *                             made regarding the number of responses, and the returned list may be empty. If
+     *                             zero, it is expected that no responses are sent during the timeout period.
+     * @param stopAfter if true, the subscription will be stopped after the messages were received (or timeout).
+     * @return The list containing the expected number of responses. The list contains the responses in the order they
+     * were received. If more responses are received than minimally expected, {@link #getRemainingResponses()}  can
+     * be used to retrieved them.
+     */
+    public List<GraphQLResponse> awaitAndGetNextResponses(
+        final int timeout,
+        final int numExpectedResponses,
+        final boolean stopAfter
+    ) {
+        if (!started) {
+            fail("Start message not sent. Please send start message first.");
+        }
+        if (stopped) {
+            fail("Subscription already stopped. Forgot to call reset after test case?");
+        }
+        int elapsedTime = 0;
+        while (
+            ((responses.size() < numExpectedResponses) || numExpectedResponses <= 0)
+            && elapsedTime < timeout
+        ) {
+            try {
+                Thread.sleep(SLEEP_INTERVAL_MS);
+                elapsedTime += SLEEP_INTERVAL_MS;
+            } catch (InterruptedException e) {
+                fail("Test execution error - Thread.sleep failed.", e);
+            }
+        }
+        synchronized (responses) {
+            if (stopAfter) {
+                stop();
+            }
+            int responsesToPoll = responses.size();
+            if (numExpectedResponses == 0) {
+                assertThat(responses)
+                    .as(String.format("Expected no responses in %s MS, but received %s", timeout, responses.size()))
+                    .isEmpty();
+            }
+            if (numExpectedResponses > 0) {
+                assertThat(responses)
+                    .as("Expected at least %s message(s) in %d MS, but %d received.",
+                        numExpectedResponses,
+                        timeout,
+                        responses.size())
+                    .hasSizeGreaterThanOrEqualTo(numExpectedResponses);
+                responsesToPoll = numExpectedResponses;
+            }
+            final List<GraphQLResponse> responseList = new ArrayList<>();
+            for (int i = 0; i < responsesToPoll; i++) {
+                responseList.add(responses.poll());
+            }
+            log.debug("Returning {} responses.", responseList.size());
+            return responseList;
+        }
+    }
+
+    /**
+     * Waits a specified amount of time and asserts that no responses were received during that time.
+     * @param timeToWait time to wait, in milliseconds.
+     * @param stopAfter if true, the subscription will be stopped afterwards.
+     */
+    public GraphQLTestSubscription waitAndExpectNoResponse(final int timeToWait, final boolean stopAfter) {
+        awaitAndGetNextResponses(timeToWait, 0, stopAfter);
+        return this;
+    }
+
+    /**
+     * Waits a specified amount of time and asserts that no responses were received during that time. The subscription
+     * will be stopped afterwards.
+     * @param timeToWait time to wait, in milliseconds.
+     */
+    public GraphQLTestSubscription waitAndExpectNoResponse(final int timeToWait) {
+        awaitAndGetNextResponses(timeToWait, 0, true);
+        return this;
+    }
+
+    /**
+     * Returns the remaining responses that were not returned so far. This method should only be called after
+     * the subscription was stopped.
+     * @return the remaining responses.
+     */
+    public List<GraphQLResponse> getRemainingResponses() {
+        if (!stopped) {
+            fail("getRemainingResponses should only be called after the subscription was stopped.");
+        }
+        final ArrayList<GraphQLResponse> graphQLResponses = new ArrayList<>(responses);
+        responses.clear();
+        return graphQLResponses;
+    }
+
+    private void initClient() throws Exception {
+        final WebSocketContainer webSocketContainer = ContainerProvider.getWebSocketContainer();
+        final String port = environment.getProperty("local.server.port");
+        final URI uri = URI.create(String.format("ws://localhost:%s/%s", port, subscriptionPath));
+        log.debug("Connecting to client at {}", uri);
+        final ClientEndpointConfig clientEndpointConfig = ClientEndpointConfig.Builder.create()
+            .configurator(new TestWebSocketClientConfigurator())
+            .build();
+        session = webSocketContainer.connectToServer(TestWebSocketClient.class, clientEndpointConfig, uri);
+        session.addMessageHandler(new TestMessageHandler());
+    }
+
+    private JsonNode getFinalPayload(final Object variables) {
+        return (JsonNode) Optional.ofNullable(variables)
+            .map(objectMapper::valueToTree)
+            .orElseGet(objectMapper::createObjectNode);
+    }
+
+    private String loadQuery(final String graphGLResource) {
+        try {
+            final File file = ResourceUtils.getFile("classpath:" + graphGLResource);
+            return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            fail(String.format("Test setup failure - could not load GraphQL resource: %s", graphGLResource), e);
+            return "";
+        }
+    }
+
+    private void sendMessage(final Object message) {
+        try {
+            session.getBasicRemote().sendText(objectMapper.writeValueAsString(message));
+        } catch (IOException e) {
+            fail("Test setup failure - cannot serialize subscription payload.", e);
+        }
+    }
+
+    class TestMessageHandler implements MessageHandler.Whole<String> {
+        @Override
+        public void onMessage(final String message) {
+            try {
+                log.debug("Received message from web socket: {}", message);
+                final JsonNode jsonNode = objectMapper.readTree(message);
+                final JsonNode type = jsonNode.get("type");
+                if (type.asText().equals("connection_ack")) {
+                    acknowledged = true;
+                    log.debug("WebSocket connection acknowledged by the GraphQL Server.");
+                } else if (type.asText().equals("data")) {
+                    final JsonNode data = jsonNode.get("payload");
+                    assertThat(data).as("Data message must have a payload.").isNotNull();
+                    final GraphQLResponse graphQLResponse
+                        = new GraphQLResponse(ResponseEntity.ok(objectMapper.writeValueAsString(data)), objectMapper);
+                    synchronized (responses) {
+                        responses.add(graphQLResponse);
+                    }
+                }
+            } catch (JsonProcessingException e) {
+                fail("Exception while parsing server response. Response is not a valid GraphQL response.", e);
+            }
+        }
+    }
+
+    public static class TestWebSocketClient extends Endpoint {
+        @Override
+        public void onOpen(final Session session, final EndpointConfig config) {
+            log.debug("Connection established.");
+        }
+    }
+
+    static class TestWebSocketClientConfigurator extends ClientEndpointConfig.Configurator {
+
+        @Override
+        public void beforeRequest(final Map<String, List<String>> headers) {
+            super.beforeRequest(headers);
+            headers.put("sec-websocket-protocol", Collections.singletonList("graphql-ws"));
+        }
+    }
+}

--- a/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestSubscription.java
+++ b/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestSubscription.java
@@ -12,6 +12,8 @@ import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ResourceUtils;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import org.springframework.web.util.UriBuilderFactory;
 
 import javax.websocket.ClientEndpointConfig;
 import javax.websocket.ContainerProvider;
@@ -46,6 +48,7 @@ public class GraphQLTestSubscription {
 
     private static final int SLEEP_INTERVAL_MS = 100;
     private static final AtomicInteger ID_COUNTER = new AtomicInteger(1);
+    private static final UriBuilderFactory URI_BUILDER_FACTORY = new DefaultUriBuilderFactory();
 
     @Getter
     private Session session;
@@ -339,7 +342,8 @@ public class GraphQLTestSubscription {
     private void initClient() throws Exception {
         final WebSocketContainer webSocketContainer = ContainerProvider.getWebSocketContainer();
         final String port = environment.getProperty("local.server.port");
-        final URI uri = URI.create(String.format("ws://localhost:%s/%s", port, subscriptionPath));
+        final URI uri = URI_BUILDER_FACTORY.builder().scheme("ws").host("localhost").port(port).path(subscriptionPath)
+            .build();
         log.debug("Connecting to client at {}", uri);
         final ClientEndpointConfig clientEndpointConfig = ClientEndpointConfig.Builder.create()
             .configurator(new TestWebSocketClientConfigurator())

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLResponseTest.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLResponseTest.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = TestApplication.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class GraphQLResponseTest {
 
     private static final String DATA_PATH = "$.data.test";

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLSubscriptionTestAwaitNoAnswerTest.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLSubscriptionTestAwaitNoAnswerTest.java
@@ -1,0 +1,58 @@
+package com.graphql.spring.boot.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@DisplayName("Testing awaitNoResponse methods")
+public class GraphQLSubscriptionTestAwaitNoAnswerTest extends GraphQLTestSubscriptionTestBase {
+
+    @Test
+    @DisplayName("Should succeed if no responses arrived / default stopAfter.")
+    void shouldAwaitNoResponseSucceedIfNoResponsesArrivedDefaultStopAfter() {
+        // WHEN - THEN
+        graphQLTestSubscription
+            .start(SUBSCRIPTION_THAT_TIMES_OUT_RESOURCE)
+            .waitAndExpectNoResponse(TIMEOUT);
+        assertThatSubscriptionWasStopped();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @DisplayName("Should succeed if no responses arrive.")
+    void shouldAwaitNoResponseSucceedIfNoResponsesArrived(
+        final boolean stopAfter
+    ) {
+        // WHEN - THEN
+        graphQLTestSubscription
+            .start(SUBSCRIPTION_THAT_TIMES_OUT_RESOURCE)
+            .waitAndExpectNoResponse(TIMEOUT, stopAfter);
+        assertThatSubscriptionStoppedStatusIs(stopAfter);
+    }
+
+    @Test
+    @DisplayName("Should raise assertion error if any response arrived / default stop after.")
+    void shouldRaiseAssertionErrorIfResponseArrivedDefaultStopAfter() {
+        // WHEN - THEN
+        assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> graphQLTestSubscription
+            .start(TIMER_SUBSCRIPTION_RESOURCE)
+            .waitAndExpectNoResponse(TIMEOUT));
+        assertThatSubscriptionWasStopped();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @DisplayName("Should raise assertion error if any response arrived.")
+    void shouldRaiseAssertionErrorIfResponseArrived(
+        final boolean stopAfter
+    ) {
+        // WHEN - THEN
+        assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> graphQLTestSubscription
+            .start(TIMER_SUBSCRIPTION_RESOURCE)
+            .waitAndExpectNoResponse(TIMEOUT, stopAfter));
+        assertThatSubscriptionStoppedStatusIs(stopAfter);
+    }
+}

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionAwaitAndGetResponseTest.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionAwaitAndGetResponseTest.java
@@ -1,0 +1,131 @@
+package com.graphql.spring.boot.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GraphQLTestSubscriptionAwaitAndGetResponseTest extends GraphQLTestSubscriptionTestBase {
+
+    @Test
+    @DisplayName("Should await and get single response.")
+    void shouldAwaitAndGetResponse() {
+        // WHEN
+        final GraphQLResponse graphQLResponse = graphQLTestSubscription
+            .start(TIMER_SUBSCRIPTION_RESOURCE)
+            .awaitAndGetNextResponse(TIMEOUT);
+        // THEN
+        assertThat(graphQLResponse.get(DATA_TIMER_FIELD, Long.class)).isEqualTo(0);
+        assertThatSubscriptionWasStopped();
+    }
+
+    @Test
+    @DisplayName("Should await and get multiple responses.")
+    void shouldAwaitAndGetMultipleResponses() {
+        // WHEN
+        final List<GraphQLResponse> graphQLResponses = graphQLTestSubscription
+            .start(TIMER_SUBSCRIPTION_RESOURCE)
+            .awaitAndGetNextResponses(TIMEOUT, 5);
+        // THEN
+        assertThat(graphQLResponses)
+            .extracting(response -> response.get(DATA_TIMER_FIELD, Long.class))
+            .containsExactly(0L, 1L, 2L, 3L, 4L);
+        assertThatSubscriptionWasStopped();
+    }
+
+    @Test
+    @DisplayName("Should await and get all responses / default stopAfter.")
+    void shouldAwaitAndGetAllResponsesDefaultStopAfter() {
+        // WHEN
+        final List<GraphQLResponse> graphQLResponses = graphQLTestSubscription
+            .start(TIMER_SUBSCRIPTION_RESOURCE)
+            .awaitAndGetAllResponses(TIMEOUT);
+        // THEN
+        assertThat(graphQLResponses)
+            .extracting(response -> response.get(DATA_TIMER_FIELD, Long.class))
+            .containsExactly(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
+        assertThatSubscriptionWasStopped();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @DisplayName("Should await and get all responses.")
+    void shouldAwaitAndGetAllResponses(
+        final boolean stopAfter
+    ) {
+        // WHEN
+        final List<GraphQLResponse> graphQLResponses = graphQLTestSubscription
+            .start(TIMER_SUBSCRIPTION_RESOURCE)
+            .awaitAndGetAllResponses(TIMEOUT, stopAfter);
+        // THEN
+        assertThat(graphQLResponses)
+            .extracting(response -> response.get(DATA_TIMER_FIELD, Long.class))
+            .containsExactly(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
+        assertThatSubscriptionStoppedStatusIs(stopAfter);
+    }
+
+    @Test
+    @DisplayName("Should handle multiple subsequent await and get calls, assuming stopAfter was false.")
+    void shouldWorkWithMultipleAwaitAndGetCalls() {
+        // GIVEN
+        graphQLTestSubscription.start(TIMER_SUBSCRIPTION_RESOURCE);
+
+        // WHEN
+        final GraphQLResponse graphQLResponse = graphQLTestSubscription.awaitAndGetNextResponse(TIMEOUT, false);
+        // THEN
+        assertThat(graphQLResponse.get(DATA_TIMER_FIELD, Long.class)).isEqualTo(0);
+        assertThatSubscriptionWasNotStopped();
+
+        // WHEN
+        final List<GraphQLResponse> graphQLResponses = graphQLTestSubscription.awaitAndGetNextResponses(TIMEOUT, 3, false);
+        // THEN
+        assertThat(graphQLResponses)
+            .extracting(response -> response.get(DATA_TIMER_FIELD, Long.class))
+            .containsExactly(1L, 2L, 3L);
+        assertThatSubscriptionWasNotStopped();
+
+        // WHEN
+        final List<GraphQLResponse> graphQLResponses2 = graphQLTestSubscription.awaitAndGetAllResponses(TIMEOUT);
+        // THEN
+        assertThat(graphQLResponses2)
+            .extracting(response -> response.get(DATA_TIMER_FIELD, Long.class))
+            .containsExactly(4L, 5L, 6L, 7L, 8L, 9L);
+        assertThatSubscriptionWasStopped();
+    }
+
+    @Test
+    @DisplayName("Should properly handle subscriptions with input variables.")
+    void shouldHandleSubscriptionWithParameters() {
+        // GIVEN
+        final String param = String.valueOf(UUID.randomUUID());
+        final Map<String, String> startPayload = Collections.singletonMap("param", param);
+        // WHEN
+        final GraphQLResponse graphQLResponse = graphQLTestSubscription
+            .start(SUBSCRIPTION_WITH_PARAMETER_RESOURCE, startPayload)
+            .awaitAndGetNextResponse(TIMEOUT);
+        // THEN
+        assertThat(graphQLResponse.get(DATA_SUBSCRIPTION_WITH_PARAMETER_FIELD)).isEqualTo(param);
+    }
+
+    @Test
+    @DisplayName("Should properly work with subscriptions that expect an init payload.")
+    void shouldSubscriptionWithInitPayload() {
+        // GIVEN
+        final String initParamValue = String.valueOf(UUID.randomUUID());
+        final Map<String, String> initPayload = Collections.singletonMap("initParamValue", initParamValue);
+        // WHEN
+        final GraphQLResponse graphQLResponse = graphQLTestSubscription
+            .init(initPayload)
+            .start(SUBSCRIPTION_WITH_INIT_PAYLOAD_RESOURCE)
+            .awaitAndGetNextResponse(TIMEOUT);
+        // THEN
+        assertThat(graphQLResponse.get(DATA_SUBSCRIPTION_WITH_INIT_PAYLOAD_FIELD)).isEqualTo(initParamValue);
+    }
+}

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionErrorTest.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionErrorTest.java
@@ -1,0 +1,20 @@
+package com.graphql.spring.boot.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Test error message handling.")
+public class GraphQLTestSubscriptionErrorTest extends GraphQLTestSubscriptionTestBase {
+
+    @Test
+    @DisplayName("Should handle error messages.")
+    void shouldHandleErrorMessages() {
+        // WHEN
+        final GraphQLResponse graphQLResponse = graphQLTestSubscription.start(SUBSCRIPTION_THAT_THROWS_EXCEPTION)
+            .awaitAndGetNextResponse(TIMEOUT);
+        // THEN
+        assertThat(graphQLResponse.get("$.errors[0].message")).isNotBlank();
+    }
+}

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionGetRemainingResponsesTest.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionGetRemainingResponsesTest.java
@@ -1,0 +1,33 @@
+package com.graphql.spring.boot.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@DisplayName("Testing getRemainingResponses")
+public class GraphQLTestSubscriptionGetRemainingResponsesTest extends GraphQLTestSubscriptionTestBase {
+
+    @Test
+    @DisplayName("Should properly return remaining responses after the Subscription was stopped.")
+    void shouldGetRemainingResponses() throws InterruptedException {
+        // WHEN
+        graphQLTestSubscription.start(TIMER_SUBSCRIPTION_RESOURCE).awaitAndGetNextResponse(TIMEOUT, false);
+        Thread.sleep(TIMEOUT);
+        graphQLTestSubscription.stop();
+        // THEN
+        assertThatSubscriptionWasStopped();
+        assertThat(graphQLTestSubscription.getRemainingResponses())
+            .extracting(graphQLResponse -> graphQLResponse.get(DATA_TIMER_FIELD, Long.class))
+            .containsExactly(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
+    }
+
+    @Test
+    @DisplayName("Should raise assertion error if called before the subscription was stopped.")
+    void shouldRaiseAssertionErrorIfCalledBeforeSubscriptionIsStopped() {
+        // WHEN - THEN
+        assertThatExceptionOfType(AssertionError.class)
+            .isThrownBy(() -> graphQLTestSubscription.getRemainingResponses());
+    }
+}

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionResetTest.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionResetTest.java
@@ -1,0 +1,83 @@
+package com.graphql.spring.boot.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Testing reset")
+public class GraphQLTestSubscriptionResetTest extends GraphQLTestSubscriptionTestBase {
+
+    @Test
+    @DisplayName("Should work if subscription was not yet started.")
+    void shouldWorkIfSubscriptionWasNotStarted() {
+        // WHEN
+        final int firstId = getSubscriptionId();
+        graphQLTestSubscription.reset();
+        // THEN
+        assertThatSubscriptionWasReset();
+        assertThatExistingIdWasRetained(firstId);
+    }
+
+    @Test
+    @DisplayName("Should work if subscription is still active.")
+    void shouldWorkIfSubscriptionIsStillActive() {
+        // GIVEN
+        final int firstId = getSubscriptionId();
+        graphQLTestSubscription.start(TIMER_SUBSCRIPTION_RESOURCE);
+        // WHEN
+        graphQLTestSubscription.reset();
+        // THEN
+        assertThatSubscriptionWasReset();
+        assertThatNewIdWasGenerated(firstId);
+    }
+
+    @Test
+    @DisplayName("Should work if subscription was stopped.")
+    void shouldWorkIfSubscriptionWasAlreadyStopped() {
+        // GIVEN
+        final int firstId = getSubscriptionId();
+        graphQLTestSubscription.start(TIMER_SUBSCRIPTION_RESOURCE).stop();
+        // WHEN
+        graphQLTestSubscription.reset();
+        // THEN
+        assertThatSubscriptionWasReset();
+        assertThatNewIdWasGenerated(firstId);
+    }
+
+    @Test
+    @DisplayName("Should allow starting a new subscription after reset.")
+    void shouldAllowStartingNewSubscriptionAfterReset() {
+        // GIVEN
+        graphQLTestSubscription.start(TIMER_SUBSCRIPTION_RESOURCE);
+        // WHEN
+        graphQLTestSubscription.reset();
+        // THEN
+        graphQLTestSubscription.start(TIMER_SUBSCRIPTION_RESOURCE);
+    }
+
+    private void assertThatSubscriptionWasReset() {
+        assertThat(graphQLTestSubscription.isInitialized()).isFalse();
+        assertThat(graphQLTestSubscription.isAcknowledged()).isFalse();
+        assertThat(graphQLTestSubscription.isStarted()).isFalse();
+        assertThat(graphQLTestSubscription.isStopped()).isFalse();
+        assertThat((Queue<?>) ReflectionTestUtils.getField(graphQLTestSubscription, GraphQLTestSubscription.class,
+            "responses")).isEmpty();
+        assertThat(graphQLTestSubscription.getSession()).isNull();
+    }
+
+    private void assertThatNewIdWasGenerated(int previousId) {
+        assertThat(getSubscriptionId()).isEqualTo(previousId + 1);
+    }
+
+    private void assertThatExistingIdWasRetained(int previousId) {
+        assertThat(getSubscriptionId()).isEqualTo(previousId);
+    }
+
+    private int getSubscriptionId() {
+        return (int) ReflectionTestUtils.getField(graphQLTestSubscription, GraphQLTestSubscription.class, "id");
+    }
+}

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionTestBase.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionTestBase.java
@@ -1,0 +1,57 @@
+package com.graphql.spring.boot.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class GraphQLTestSubscriptionTestBase {
+
+    protected static final String TIMER_SUBSCRIPTION_RESOURCE = "timer-subscription-resource.graphql";
+    protected static final String SUBSCRIPTION_WITH_PARAMETER_RESOURCE = "subscription-with-param-resource.graphql";
+    protected static final String SUBSCRIPTION_WITH_INIT_PAYLOAD_RESOURCE
+        = "subscription-with-init-payload-resource.graphql";
+    protected static final String SUBSCRIPTION_THAT_TIMES_OUT_RESOURCE
+        = "subscription-that-times-out-resource.graphql";
+    protected static final String DATA_TIMER_FIELD = "$.data.timer";
+    protected static final String DATA_SUBSCRIPTION_WITH_PARAMETER_FIELD = "$.data.subscriptionWithParameter";
+    protected static final String DATA_SUBSCRIPTION_WITH_INIT_PAYLOAD_FIELD = "$.data.subscriptionWithInitPayload";
+    protected static final int TIMEOUT = 2000;
+
+    @Autowired
+    protected Environment environment;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected GraphQLTestSubscription graphQLTestSubscription;
+
+    @BeforeEach
+    protected void setUp() {
+        graphQLTestSubscription = new GraphQLTestSubscription(environment, objectMapper, "subscriptions");
+    }
+
+    protected void assertThatSubscriptionStoppedStatusIs(boolean isStopped) {
+        if (isStopped) {
+            assertThatSubscriptionWasStopped();
+        } else {
+            assertThatSubscriptionWasNotStopped();
+        }
+    }
+
+    protected void assertThatSubscriptionWasStopped() {
+        assertThat(graphQLTestSubscription.isStopped())
+            .as("Subscription should be stopped.")
+            .isTrue();
+    }
+
+    protected void assertThatSubscriptionWasNotStopped() {
+        assertThat(graphQLTestSubscription.isStopped())
+            .as("Subscription should not be stopped.")
+            .isFalse();
+    }
+}

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionTestBase.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionTestBase.java
@@ -17,6 +17,8 @@ public class GraphQLTestSubscriptionTestBase {
         = "subscription-with-init-payload-resource.graphql";
     protected static final String SUBSCRIPTION_THAT_TIMES_OUT_RESOURCE
         = "subscription-that-times-out-resource.graphql";
+    protected static final String SUBSCRIPTION_THAT_THROWS_EXCEPTION
+        = "subscription-that-throws-exception-resource.graphql";
     protected static final String DATA_TIMER_FIELD = "$.data.timer";
     protected static final String DATA_SUBSCRIPTION_WITH_PARAMETER_FIELD = "$.data.subscriptionWithParameter";
     protected static final String DATA_SUBSCRIPTION_WITH_INIT_PAYLOAD_FIELD = "$.data.subscriptionWithInitPayload";

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionUsageErrorHandlingTest.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionUsageErrorHandlingTest.java
@@ -1,0 +1,64 @@
+package com.graphql.spring.boot.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@DisplayName("Testing if usage errors are properly handled.")
+public class GraphQLTestSubscriptionUsageErrorHandlingTest extends GraphQLTestSubscriptionTestBase {
+
+    @Test
+    @DisplayName("Should raise an assertion error if init is called after init.")
+    void shouldRaiseAssertionErrorIfInitAfterInit() {
+        assertThatExceptionOfType(AssertionError.class)
+            .isThrownBy(() -> graphQLTestSubscription.init().init());
+    }
+
+    @Test
+    @DisplayName("Should raise an assertion error if awaitAndGet times out.")
+    void shouldRaiseAssertionErrorIfAwaitAndGetTimesOut() {
+        assertThatExceptionOfType(AssertionError.class)
+            .isThrownBy(() -> graphQLTestSubscription
+                .start(SUBSCRIPTION_THAT_TIMES_OUT_RESOURCE)
+                .awaitAndGetNextResponse(TIMEOUT));
+    }
+
+    @Test
+    @DisplayName("Should raise an assertion error if awaitAndGet methods are called before start.")
+    void shouldRaiseAssertionErrorIfGettingResponseWithoutStart() {
+        assertThatExceptionOfType(AssertionError.class)
+            .isThrownBy(() -> graphQLTestSubscription.init().awaitAndGetNextResponse(TIMEOUT));
+    }
+
+    @Test
+    @DisplayName("Should raise an assertion error if stop is called before init.")
+    void shouldRaiseAssertionErrorIfStopWithoutStart() {
+        assertThatExceptionOfType(AssertionError.class)
+            .isThrownBy(() -> graphQLTestSubscription.stop());
+    }
+
+    @Test
+    @DisplayName("Should raise an assertion error if stop is called after stop.")
+    void shouldRaiseAssertionErrorIfStopAfterStop() {
+        assertThatExceptionOfType(AssertionError.class)
+            .isThrownBy(() -> graphQLTestSubscription.start(TIMER_SUBSCRIPTION_RESOURCE).stop().stop());
+    }
+
+    @Test
+    @DisplayName("Should raise an assertion error if awaitAndGet methods are called after stop.")
+    void shouldRaiseAssertionErrorIfGettingResponseAfterStop() {
+        assertThatExceptionOfType(AssertionError.class)
+            .isThrownBy(() -> graphQLTestSubscription
+                .start(TIMER_SUBSCRIPTION_RESOURCE)
+                .stop()
+                .awaitAndGetNextResponse(TIMEOUT));
+    }
+
+    @Test
+    @DisplayName("Should raise an assertion error if the provided GraphQL resource could not be found.")
+    void shouldRaiseAssertionErrorIfGraphQLResourceCouldNotBeFound() {
+        assertThatExceptionOfType(AssertionError.class)
+            .isThrownBy(() -> graphQLTestSubscription.start("non-existing-file.graphql"));
+    }
+}

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/beans/DummyQuery.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/beans/DummyQuery.java
@@ -1,0 +1,12 @@
+package com.graphql.spring.boot.test.beans;
+
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DummyQuery implements GraphQLQueryResolver {
+
+    public boolean dummy() {
+        return true;
+    }
+}

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/beans/SubscriptionListener.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/beans/SubscriptionListener.java
@@ -1,0 +1,31 @@
+package com.graphql.spring.boot.test.beans;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.kickstart.execution.subscriptions.SubscriptionSession;
+import graphql.kickstart.execution.subscriptions.apollo.ApolloSubscriptionConnectionListener;
+import graphql.kickstart.execution.subscriptions.apollo.OperationMessage;
+import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionListener implements ApolloSubscriptionConnectionListener {
+
+    private final ObjectMapper objectMapper;
+
+    @Getter
+    private String expectedConnectionInitParamValue;
+
+    @Override
+    public void onConnect(final SubscriptionSession session, final OperationMessage message) {
+        final InitPayload initPayload = objectMapper.convertValue(message.getPayload(), InitPayload.class);
+        expectedConnectionInitParamValue = initPayload.getInitParamValue();
+    }
+
+    @Data
+    private static class InitPayload {
+        private String initParamValue;
+    }
+}

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/beans/TestSubscriptions.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/beans/TestSubscriptions.java
@@ -29,4 +29,8 @@ public class TestSubscriptions implements GraphQLSubscriptionResolver {
     public Flowable<Long> subscriptionThatTimesOut() {
         return Flowable.interval(20000, 20000, TimeUnit.MILLISECONDS);
     }
+
+    public Flowable<Boolean> subscriptionThatThrowsException() {
+        throw new RuntimeException("Test exception.");
+    }
 }

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/beans/TestSubscriptions.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/beans/TestSubscriptions.java
@@ -1,0 +1,32 @@
+package com.graphql.spring.boot.test.beans;
+
+import graphql.kickstart.tools.GraphQLSubscriptionResolver;
+import io.reactivex.Flowable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class TestSubscriptions implements GraphQLSubscriptionResolver {
+
+    private final SubscriptionListener subscriptionListener;
+
+    public Flowable<Long> timer() {
+        return Flowable
+            .intervalRange(0, 10, 0,1, TimeUnit.MILLISECONDS);
+    }
+
+    public Flowable<String> subscriptionWithParameter(final String param) {
+        return Flowable.just(param);
+    }
+
+    public Flowable<String> subscriptionWithInitPayload() {
+        return Flowable.just(subscriptionListener.getExpectedConnectionInitParamValue());
+    }
+
+    public Flowable<Long> subscriptionThatTimesOut() {
+        return Flowable.interval(20000, 20000, TimeUnit.MILLISECONDS);
+    }
+}

--- a/graphql-spring-boot-test/src/test/resources/application.yaml
+++ b/graphql-spring-boot-test/src/test/resources/application.yaml
@@ -1,0 +1,3 @@
+logging.level:
+  graphql.servlet: debug
+  com.graphql.spring.boot.test: debug

--- a/graphql-spring-boot-test/src/test/resources/subscription-that-throws-exception-resource.graphql
+++ b/graphql-spring-boot-test/src/test/resources/subscription-that-throws-exception-resource.graphql
@@ -1,0 +1,3 @@
+subscription {
+    subscriptionThatThrowsException
+}

--- a/graphql-spring-boot-test/src/test/resources/subscription-that-times-out-resource.graphql
+++ b/graphql-spring-boot-test/src/test/resources/subscription-that-times-out-resource.graphql
@@ -1,0 +1,3 @@
+subscription {
+    subscriptionThatTimesOut
+}

--- a/graphql-spring-boot-test/src/test/resources/subscription-with-init-payload-resource.graphql
+++ b/graphql-spring-boot-test/src/test/resources/subscription-with-init-payload-resource.graphql
@@ -1,0 +1,3 @@
+subscription {
+    subscriptionWithInitPayload
+}

--- a/graphql-spring-boot-test/src/test/resources/subscription-with-param-resource.graphql
+++ b/graphql-spring-boot-test/src/test/resources/subscription-with-param-resource.graphql
@@ -1,0 +1,3 @@
+subscription ($param: String!){
+    subscriptionWithParameter(param: $param)
+}

--- a/graphql-spring-boot-test/src/test/resources/test-schema.graphqls
+++ b/graphql-spring-boot-test/src/test/resources/test-schema.graphqls
@@ -5,6 +5,7 @@ type Subscription {
     subscriptionWithParameter(param: String!): String!
     subscriptionWithInitPayload: String!
     subscriptionThatTimesOut: Long!
+    subscriptionThatThrowsException: Boolean!
 }
 
 type Query {

--- a/graphql-spring-boot-test/src/test/resources/test-schema.graphqls
+++ b/graphql-spring-boot-test/src/test/resources/test-schema.graphqls
@@ -1,0 +1,12 @@
+scalar Long
+
+type Subscription {
+    timer: Long!
+    subscriptionWithParameter(param: String!): String!
+    subscriptionWithInitPayload: String!
+    subscriptionThatTimesOut: Long!
+}
+
+type Query {
+    dummy: Boolean!
+}

--- a/graphql-spring-boot-test/src/test/resources/timer-subscription-resource.graphql
+++ b/graphql-spring-boot-test/src/test/resources/timer-subscription-resource.graphql
@@ -1,0 +1,3 @@
+subscription {
+    timer
+}


### PR DESCRIPTION
This PR adds a new `GraphQLTestSubscription`, which is intended to serve the same purpose as the current `GraphQLTestTemplate`, but for subscriptions.

Originally I planned to demonstrate its usage by adding tests to the existing subscription example project. However, currently it emits values randomly which makes it hard to test reliably.

_Update_: added WIP marker because the auto-configure part is not properly tested.