### PR TITLE
Feature/build script adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,19 +81,19 @@ repositories {
 }
 
 dependencies {
-  compile 'com.graphql-java-kickstart:graphql-spring-boot-starter:7.0.1'
+  implementation 'com.graphql-java-kickstart:graphql-spring-boot-starter:7.0.1'
   
   // to embed Altair tool
-  runtime 'com.graphql-java-kickstart:altair-spring-boot-starter:7.0.1'
+  runtimeOnly 'com.graphql-java-kickstart:altair-spring-boot-starter:7.0.1'
 
   // to embed GraphiQL tool
-  runtime 'com.graphql-java-kickstart:graphiql-spring-boot-starter:7.0.1'
+  runtimeOnly 'com.graphql-java-kickstart:graphiql-spring-boot-starter:7.0.1'
 
   // to embed Voyager tool
-  runtime 'com.graphql-java-kickstart:voyager-spring-boot-starter:7.0.1'
+  runtimeOnly 'com.graphql-java-kickstart:voyager-spring-boot-starter:7.0.1'
   
   // testing facilities
-  testCompile 'com.graphql-java-kickstart:graphql-spring-boot-starter-test:7.0.1'
+  testImplementation 'com.graphql-java-kickstart:graphql-spring-boot-starter-test:7.0.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,7 @@ subprojects {
         }
 
         artifactory {
-            contextUrl = 'http://oss.jfrog.org'
+            contextUrl = 'https://oss.jfrog.org'
             publish {
                 repository {
                     if (project.version.endsWith("-SNAPSHOT")) {

--- a/example-graphql-subscription/build.gradle
+++ b/example-graphql-subscription/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: "org.springframework.boot"
+
 dependencies {
     implementation(project(":graphql-spring-boot-starter"))
     implementation(project(":graphiql-spring-boot-starter"))

--- a/example-graphql-tools/build.gradle
+++ b/example-graphql-tools/build.gradle
@@ -17,6 +17,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+apply plugin: "org.springframework.boot"
+
 dependencies {
     implementation(project(":graphql-spring-boot-starter"))
     implementation(project(":graphiql-spring-boot-starter"))

--- a/example-request-scoped-dataloader/build.gradle
+++ b/example-request-scoped-dataloader/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: "org.springframework.boot"
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation(project(":graphql-spring-boot-starter"))

--- a/example-spring-common/build.gradle
+++ b/example-spring-common/build.gradle
@@ -35,3 +35,4 @@ dependencies{
 jar.enabled = false
 uploadArchives.enabled = false
 bintrayUpload.enabled = false
+publishToMavenLocal.enabled = false

--- a/example-webflux/build.gradle
+++ b/example-webflux/build.gradle
@@ -17,13 +17,15 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-dependencies {
-    compile(project(":graphql-kickstart-spring-boot-starter-webflux"))
-    compile(project(":graphql-kickstart-spring-boot-starter-tools"))
-    compile(project(":voyager-spring-boot-starter"))
+apply plugin: "org.springframework.boot"
 
-    compile("org.springframework.boot:spring-boot-starter-webflux:$LIB_SPRING_BOOT_VER")
-    compile("org.springframework.boot:spring-boot-starter-actuator:$LIB_SPRING_BOOT_VER")
+dependencies {
+    implementation(project(":graphql-kickstart-spring-boot-starter-webflux"))
+    implementation(project(":graphql-kickstart-spring-boot-starter-tools"))
+    implementation(project(":voyager-spring-boot-starter"))
+
+    implementation("org.springframework.boot:spring-boot-starter-webflux:$LIB_SPRING_BOOT_VER")
+    implementation("org.springframework.boot:spring-boot-starter-actuator:$LIB_SPRING_BOOT_VER")
 }
 
 jar.enabled = false

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -17,6 +17,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+apply plugin: "org.springframework.boot"
+
 dependencies{
     implementation(project(":altair-spring-boot-starter"))
     implementation(project(":graphql-spring-boot-starter"))

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
These are mostly follow-up improvements/fixes of the earlier major build script refactor:
- apply Spring Boot plugin to example apps (allows running them via `bootRun` Gradle task)
- disable `publishToMavenLocal` task for example-spring-common
- update deprecated `compile` scope to `implementation` (example-webflux)
- use `https` instead of `http` for Artifactory
- update deprecated Gradle dependency configuration in readme