### PR TITLE
fix: GraphQLTestSubscription test failing

### DIFF
--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionTestBase.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionTestBase.java
@@ -1,6 +1,7 @@
 package com.graphql.spring.boot.test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,6 +36,11 @@ public class GraphQLTestSubscriptionTestBase {
     @BeforeEach
     protected void setUp() {
         graphQLTestSubscription = new GraphQLTestSubscription(environment, objectMapper, "subscriptions");
+    }
+
+    @AfterEach
+    protected void tearDown() {
+        graphQLTestSubscription.reset();
     }
 
     protected void assertThatSubscriptionStoppedStatusIs(boolean isStopped) {


### PR DESCRIPTION
Also includes some minor fixes and improvements to
GraphQLTestSubscription behaviour.

Apparently, there were several potential causes of failure on the
pipeline:
- the web socket connection was not properly closed after certain tests
(reset was not called after tests)
- web socked connection timed out (solved by increasing connection
timeout)
- value of "acknowledged" could be true after reset (init method now
waits for the "acknowledged" message to arrive)
- "responses" may not be empty after reset (solved by making clear call
synchronized)