### PR TITLE
Update GraphQLController to use ObjectMapper to map ExecutionResult

### DIFF
--- a/graphql-kickstart-spring-webflux/src/main/java/graphql/kickstart/spring/webflux/GraphQLController.java
+++ b/graphql-kickstart-spring-webflux/src/main/java/graphql/kickstart/spring/webflux/GraphQLController.java
@@ -14,13 +14,14 @@ import reactor.core.publisher.Mono;
 
 @RestController
 public class GraphQLController extends AbstractGraphQLController {
-
+  private final GraphQLObjectMapper objectMapper;
   private final GraphQLInvoker graphQLInvoker;
   private final GraphQLSpringInvocationInputFactory invocationInputFactory;
 
   public GraphQLController(GraphQLObjectMapper objectMapper, GraphQLInvoker graphQLInvoker,
       GraphQLSpringInvocationInputFactory invocationInputFactory) {
     super(objectMapper);
+    this.objectMapper = objectMapper;
     this.graphQLInvoker = graphQLInvoker;
     this.invocationInputFactory = invocationInputFactory;
   }
@@ -33,7 +34,7 @@ public class GraphQLController extends AbstractGraphQLController {
     GraphQLSingleInvocationInput invocationInput = invocationInputFactory
         .create(new GraphQLRequest(query, variables, operationName), serverWebExchange);
     Mono<ExecutionResult> executionResult = Mono.fromCompletionStage(graphQLInvoker.executeAsync(invocationInput));
-    return executionResult.map(ExecutionResult::toSpecification);
+    return executionResult.map(objectMapper::createResultFromExecutionResult);
   }
 
 }


### PR DESCRIPTION
Prior to this PR, the Webflux version of graphql-spring-boot did not use GraphQLObjectMapper to map the execution result. This meant that the error messages could not be customized by creating a custom GraphQLErrorHandler.