### PR TITLE
artifact name spelling fix in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -216,8 +216,8 @@ release {
             'com.graphql-java-kickstart:graphql-spring-boot-test-autoconfigure',
             'com.graphql-java-kickstart:voyager-spring-boot-autoconfigure',
             'com.graphql-java-kickstart:voyager-spring-boot-starter',
-            'com.graphql-java-kickstart:playgroud-spring-boot-autoconfigure',
-            'com.graphql-java-kickstart:playgroud-spring-boot-starter'
+            'com.graphql-java-kickstart:playground-spring-boot-autoconfigure',
+            'com.graphql-java-kickstart:playground-spring-boot-starter'
     ]
 }
 


### PR DESCRIPTION
ignoredSnapshotDependencies had spelling issues