### PR TITLE
refactor: migrate all tests to JUnit 5 / AssertJ

### DIFF
--- a/altair-spring-boot-autoconfigure/src/test/java/graphql/kickstart/altair/boot/test/AbstractAutoConfigurationTest.java
+++ b/altair-spring-boot-autoconfigure/src/test/java/graphql/kickstart/altair/boot/test/AbstractAutoConfigurationTest.java
@@ -1,6 +1,6 @@
 package graphql.kickstart.altair.boot.test;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigRegistry;
@@ -26,7 +26,7 @@ public abstract class AbstractAutoConfigurationTest {
         this.autoConfiguration = autoConfiguration;
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (this.context != null) {
             this.context.close();

--- a/altair-spring-boot-autoconfigure/src/test/java/graphql/kickstart/altair/boot/test/AltairControllerTest.java
+++ b/altair-spring-boot-autoconfigure/src/test/java/graphql/kickstart/altair/boot/test/AltairControllerTest.java
@@ -2,14 +2,16 @@ package graphql.kickstart.altair.boot.test;
 
 import graphql.kickstart.altair.boot.AltairAutoConfiguration;
 import graphql.kickstart.altair.boot.AltairController;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Andrew Potter
@@ -42,13 +44,14 @@ public class AltairControllerTest extends AbstractAutoConfigurationTest {
     public void altairLoads() {
         load(EnabledConfiguration.class);
 
-        Assert.assertNotNull(this.getContext().getBean(AltairController.class));
+        assertThat(this.getContext().getBean(AltairController.class)).isNotNull();
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test
     public void altairDoesNotLoad() {
         load(DisabledConfiguration.class);
 
-        this.getContext().getBean(AltairController.class);
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+            .isThrownBy(() -> this.getContext().getBean(AltairController.class));
     }
 }

--- a/example-graphql-tools/src/test/java/com/graphql/sample/boot/GraphQLServletTest.kt
+++ b/example-graphql-tools/src/test/java/com/graphql/sample/boot/GraphQLServletTest.kt
@@ -3,15 +3,14 @@ package com.graphql.sample.boot
 
 import com.graphql.spring.boot.test.GraphQLTestTemplate
 import com.graphql.spring.boot.test.GraphQLTest
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @GraphQLTest
 class GraphQLServletTest {
 
@@ -21,8 +20,8 @@ class GraphQLServletTest {
     @Test
     fun `query over HTTP POST multipart with variables returns data requires multipartconfig`() {
         val response = graphQLTestTemplate.postMultipart("query echo(\$string: String!)", """{"string":"echo"}""")
-        assertNotNull(response)
-        assertEquals(HttpStatus.OK, response.statusCode)
+        assertThat(response).isNotNull
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
     }
 
 }

--- a/example-graphql-tools/src/test/java/com/graphql/sample/boot/GraphQLToolsSampleApplicationTest.java
+++ b/example-graphql-tools/src/test/java/com/graphql/sample/boot/GraphQLToolsSampleApplicationTest.java
@@ -5,22 +5,22 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.graphql.spring.boot.test.GraphQLResponse;
 import com.graphql.spring.boot.test.GraphQLTestTemplate;
 import com.graphql.spring.boot.test.GraphQLTest;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 
 import static graphql.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @GraphQLTest
 public class GraphQLToolsSampleApplicationTest {
 
@@ -28,12 +28,12 @@ public class GraphQLToolsSampleApplicationTest {
     private GraphQLTestTemplate graphQLTestTemplate;
 
     @Test
-    @Ignore
+    @Disabled
     public void get_comments() throws IOException {
         GraphQLResponse response = graphQLTestTemplate.postForResource("graphql/post-get-comments.graphql");
         assertNotNull(response);
-        assertTrue(response.isOk());
-        assertEquals("1", response.get("$.data.post.id"));
+        assertThat(response.isOk()).isTrue();
+        assertThat(response.get("$.data.post.id")).isEqualTo("1");
     }
 
     @Test
@@ -42,8 +42,8 @@ public class GraphQLToolsSampleApplicationTest {
         fragments.add("graphql/all-comment-fields-fragment.graphql");
         GraphQLResponse response = graphQLTestTemplate.postForResource("graphql/post-get-comments-with-fragment.graphql", fragments);
         assertNotNull(response);
-        assertTrue(response.isOk());
-        assertEquals("1", response.get("$.data.post.id"));
+        assertThat((response.isOk())).isTrue();
+        assertThat(response.get("$.data.post.id")).isEqualTo("1");
     }
 
     @Test
@@ -51,8 +51,8 @@ public class GraphQLToolsSampleApplicationTest {
         ObjectNode variables = new ObjectMapper().createObjectNode();
         variables.put("text", "lorem ipsum dolor sit amet");
         GraphQLResponse response = graphQLTestTemplate.perform("graphql/create-post.graphql", variables);
-        assertNotNull(response);
-        assertNotNull(response.get("$.data.createPost.id"));
+        assertThat(response).isNotNull();
+        assertThat(response.get("$.data.createPost.id")).isNotNull();
     }
 
 }

--- a/example-graphql-tools/src/test/java/com/graphql/sample/boot/SpringBootTestWithoutWebEnvironmentTest.java
+++ b/example-graphql-tools/src/test/java/com/graphql/sample/boot/SpringBootTestWithoutWebEnvironmentTest.java
@@ -1,17 +1,17 @@
 package com.graphql.sample.boot;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
+@Disabled
 public class SpringBootTestWithoutWebEnvironmentTest {
 
     @Test
-    @Ignore
     public void loads_without_complaining_about_missing_ServerContainer() {
 
     }

--- a/example-request-scoped-dataloader/src/test/java/graphql/servlet/examples/dataloader/requestscope/ApplicationTest.java
+++ b/example-request-scoped-dataloader/src/test/java/graphql/servlet/examples/dataloader/requestscope/ApplicationTest.java
@@ -1,20 +1,19 @@
 package graphql.servlet.examples.dataloader.requestscope;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class ApplicationTest {
 
@@ -42,14 +41,13 @@ public class ApplicationTest {
         headers.add("content-type", "application/graphql");
         ResponseEntity<JsonNode> response = this.restTemplate.postForEntity("/graphql", new HttpEntity<>(requestGraphQL, headers), JsonNode.class);
 
-        assertEquals(response.getBody().toString(), "{\"data\":{\"walmartCustomers\":[{\"customerId\":101,\"name\":\"Customer Name 1\"},{\"customerId\":102,\"name\":\"Customer Name 2\"},{\"customerId\":103,\"name\":\"Customer Name 3\"},{\"customerId\":104,\"name\":\"Customer Name 4\"}]}}");
+        assertThat(response.getBody().toString()).isEqualTo("{\"data\":{\"walmartCustomers\":[{\"customerId\":101,\"name\":\"Customer Name 1\"},{\"customerId\":102,\"name\":\"Customer Name 2\"},{\"customerId\":103,\"name\":\"Customer Name 3\"},{\"customerId\":104,\"name\":\"Customer Name 4\"}]}}");
 
         repository.updateUsernameForId(101, "New Name 1");
 
         response = this.restTemplate.postForEntity("/graphql", new HttpEntity<>(requestGraphQL, headers), JsonNode.class);
 
-        assertEquals(response.getBody().toString(), "{\"data\":{\"walmartCustomers\":[{\"customerId\":101,\"name\":\"New Name 1\"},{\"customerId\":102,\"name\":\"Customer Name 2\"},{\"customerId\":103,\"name\":\"Customer Name 3\"},{\"customerId\":104,\"name\":\"Customer Name 4\"}]}}");
-        ;
+        assertThat(response.getBody().toString()).isEqualTo("{\"data\":{\"walmartCustomers\":[{\"customerId\":101,\"name\":\"New Name 1\"},{\"customerId\":102,\"name\":\"Customer Name 2\"},{\"customerId\":103,\"name\":\"Customer Name 3\"},{\"customerId\":104,\"name\":\"Customer Name 4\"}]}}");
     }
 
 

--- a/graphiql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/graphiql/boot/ReactiveGraphiQLControllerTest.java
+++ b/graphiql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/graphiql/boot/ReactiveGraphiQLControllerTest.java
@@ -1,17 +1,17 @@
 package graphql.kickstart.graphiql.boot;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebFluxTest
 public class ReactiveGraphiQLControllerTest {
 

--- a/graphiql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/graphiql/boot/ServletGraphiQLControllerTest.java
+++ b/graphiql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/graphiql/boot/ServletGraphiQLControllerTest.java
@@ -1,20 +1,20 @@
 package graphql.kickstart.graphiql.boot;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest
 public class ServletGraphiQLControllerTest {
 

--- a/graphiql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/graphiql/boot/test/AbstractAutoConfigurationTest.java
+++ b/graphiql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/graphiql/boot/test/AbstractAutoConfigurationTest.java
@@ -1,6 +1,6 @@
 package graphql.kickstart.graphiql.boot.test;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigRegistry;
@@ -26,7 +26,7 @@ public abstract class AbstractAutoConfigurationTest {
         this.autoConfiguration = autoConfiguration;
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (this.context != null) {
             this.context.close();

--- a/graphiql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/graphiql/boot/test/GraphiQLControllerTest.java
+++ b/graphiql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/graphiql/boot/test/GraphiQLControllerTest.java
@@ -2,14 +2,16 @@ package graphql.kickstart.graphiql.boot.test;
 
 import graphql.kickstart.graphiql.boot.GraphiQLAutoConfiguration;
 import graphql.kickstart.graphiql.boot.GraphiQLController;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Andrew Potter
@@ -42,13 +44,14 @@ public class GraphiQLControllerTest extends AbstractAutoConfigurationTest {
     public void graphiqlLoads() {
         load(EnabledConfiguration.class);
 
-        Assert.assertNotNull(this.getContext().getBean(GraphiQLController.class));
+        assertThat(this.getContext().getBean(GraphiQLController.class)).isNotNull();
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test
     public void graphiqlDoesNotLoad() {
         load(DisabledConfiguration.class);
 
-        this.getContext().getBean(GraphiQLController.class);
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+            .isThrownBy(() -> this.getContext().getBean(GraphiQLController.class));
     }
 }

--- a/graphql-kickstart-spring-boot-autoconfigure-tools/src/test/java/graphql/kickstart/tools/boot/AbstractAutoConfigurationTest.java
+++ b/graphql-kickstart-spring-boot-autoconfigure-tools/src/test/java/graphql/kickstart/tools/boot/AbstractAutoConfigurationTest.java
@@ -4,7 +4,8 @@ import static org.mockito.Mockito.mock;
 
 import javax.servlet.ServletContext;
 import javax.websocket.server.ServerContainer;
-import org.junit.After;
+
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -34,7 +35,7 @@ public abstract class AbstractAutoConfigurationTest {
     this.autoConfiguration = autoConfiguration;
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (this.context != null) {
       this.context.close();

--- a/graphql-kickstart-spring-boot-autoconfigure-tools/src/test/java/graphql/kickstart/tools/boot/ClasspathResourceSchemaStringProviderTest.java
+++ b/graphql-kickstart-spring-boot-autoconfigure-tools/src/test/java/graphql/kickstart/tools/boot/ClasspathResourceSchemaStringProviderTest.java
@@ -1,15 +1,15 @@
 package graphql.kickstart.tools.boot;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import java.io.IOException;
 import java.util.List;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClasspathResourceSchemaStringProviderTest extends AbstractAutoConfigurationTest {
 
@@ -19,12 +19,12 @@ public class ClasspathResourceSchemaStringProviderTest extends AbstractAutoConfi
     super(GraphQLJavaToolsAutoConfiguration.class);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     System.setProperty("graphql.tools.schemaLocationPattern", "graphql/*.gqls");
   }
 
-  @After
+  @AfterEach
   public void clear() {
     System.clearProperty("graphql.tools.schemaLocationPattern");
   }
@@ -35,8 +35,8 @@ public class ClasspathResourceSchemaStringProviderTest extends AbstractAutoConfi
     schemaStringProvider = getContext().getBean(ClasspathResourceSchemaStringProvider.class);
 
     List<String> schemaStrings = schemaStringProvider.schemaStrings();
-    assertEquals(1, schemaStrings.size());
-    assertTrue(schemaStrings.get(0).contains("schemaLocationTest"));
+    assertThat(schemaStrings).hasSize(1);
+    assertThat(schemaStrings.get(0)).contains("schemaLocationTest");
   }
 
   @Configuration

--- a/graphql-kickstart-spring-boot-autoconfigure-tools/src/test/java/graphql/kickstart/tools/boot/GraphQLJavaToolsAutoConfigurationTest.java
+++ b/graphql-kickstart-spring-boot-autoconfigure-tools/src/test/java/graphql/kickstart/tools/boot/GraphQLJavaToolsAutoConfigurationTest.java
@@ -3,12 +3,11 @@ package graphql.kickstart.tools.boot;
 import graphql.kickstart.tools.GraphQLQueryResolver;
 import graphql.kickstart.tools.SchemaParserDictionary;
 import graphql.schema.GraphQLSchema;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author <a href="mailto:java.lang.RuntimeException@gmail.com">oEmbedler Inc.</a>
@@ -23,14 +22,14 @@ public class GraphQLJavaToolsAutoConfigurationTest extends AbstractAutoConfigura
   public void appContextLoads() {
     load(BaseConfiguration.class);
 
-    Assert.assertNotNull(this.getContext().getBean(GraphQLSchema.class));
+    assertThat(this.getContext().getBean(GraphQLSchema.class)).isNotNull();
   }
 
   @Test
   public void schemaWithInterfaceLoads() {
     load(InterfaceConfiguration.class);
 
-    Assert.assertNotNull(this.getContext().getBean(GraphQLSchema.class));
+    assertThat(this.getContext().getBean(GraphQLSchema.class)).isNotNull();
   }
 
   @Configuration

--- a/graphql-kickstart-spring-boot-autoconfigure-tools/src/test/java/graphql/kickstart/tools/boot/GraphQLToolsDirectiveTest.java
+++ b/graphql-kickstart-spring-boot-autoconfigure-tools/src/test/java/graphql/kickstart/tools/boot/GraphQLToolsDirectiveTest.java
@@ -4,8 +4,8 @@ import graphql.kickstart.tools.GraphQLQueryResolver;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.idl.SchemaDirectiveWiring;
 import graphql.schema.idl.SchemaDirectiveWiringEnvironment;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
@@ -16,7 +16,7 @@ public class GraphQLToolsDirectiveTest extends AbstractAutoConfigurationTest {
     super(GraphQLJavaToolsAutoConfiguration.class);
   }
 
-  @After
+  @AfterEach
   public void clear() {
     System.clearProperty("graphql.tools.schemaLocationPattern");
   }

--- a/graphql-kickstart-spring-support/src/test/java/graphql/kickstart/spring/error/GraphQLErrorHandlerFactoryTest.java
+++ b/graphql-kickstart-spring-support/src/test/java/graphql/kickstart/spring/error/GraphQLErrorHandlerFactoryTest.java
@@ -1,22 +1,23 @@
 package graphql.kickstart.spring.error;
 
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import graphql.GraphQLError;
 import graphql.kickstart.execution.error.GraphQLErrorHandler;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GraphQLErrorHandlerFactoryTest {
 
   @Mock
@@ -26,7 +27,7 @@ public class GraphQLErrorHandlerFactoryTest {
 
   private GraphQLErrorHandlerFactory errorHandlerFactory;
 
-  @Before
+  @BeforeEach
   public void setup() {
     Mockito.when(applicationContext.getBeanFactory()).thenReturn(beanFactory);
     Mockito.when(beanFactory.getBeanDefinitionNames()).thenReturn(new String[]{"Test"});
@@ -39,9 +40,9 @@ public class GraphQLErrorHandlerFactoryTest {
   @Test
   public void createFindsCollectionHandler() {
     GraphQLErrorHandler handler = errorHandlerFactory.create(applicationContext, true);
-    Assert.assertTrue(handler instanceof GraphQLErrorFromExceptionHandler);
+    assertThat(handler).isInstanceOf(GraphQLErrorFromExceptionHandler.class);
     GraphQLErrorFromExceptionHandler errorHandler = (GraphQLErrorFromExceptionHandler) handler;
-    Assert.assertFalse("handler.factories should not be empty", errorHandler.getFactories().isEmpty());
+    assertThat(errorHandler.getFactories()).as("handler.factories should not be empty").isNotEmpty();
   }
 
   public static class TestClass {

--- a/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/spring/web/boot/GraphQLErrorHandlerTest.java
+++ b/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/spring/web/boot/GraphQLErrorHandlerTest.java
@@ -10,8 +10,8 @@ import graphql.kickstart.execution.GraphQLObjectMapper;
 import graphql.kickstart.execution.error.GraphQLErrorHandler;
 import graphql.kickstart.spring.error.ThrowableGraphQLError;
 import graphql.schema.GraphQLSchema;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,7 +26,7 @@ public class GraphQLErrorHandlerTest extends AbstractAutoConfigurationTest {
     super(AnnotationConfigWebApplicationContext.class, GraphQLWebAutoConfiguration.class);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     System.setProperty("graphql.tools.schemaLocationPattern", "graphql/error-handler-test.graphql");
     load(BaseConfiguration.class);

--- a/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/spring/web/boot/GraphQLServletPropertiesTest.java
+++ b/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/spring/web/boot/GraphQLServletPropertiesTest.java
@@ -1,16 +1,16 @@
 package graphql.kickstart.spring.web.boot;
 
 import graphql.kickstart.execution.context.ContextSetting;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static graphql.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {"graphql.servlet.mapping=/test", "graphql.servlet.contextSetting=PER_REQUEST_WITH_INSTRUMENTATION"})
 public class GraphQLServletPropertiesTest {
 
@@ -21,12 +21,12 @@ public class GraphQLServletPropertiesTest {
     public void contains_custom_servlet_endpoint() {
         String mapping = properties.getMapping();
         assertNotNull(mapping);
-        assertEquals("/test", mapping);
+        assertThat(mapping).isEqualTo("/test");
     }
 
     @Test
     public void containsCorrectContextSetting() {
         ContextSetting contextSetting = properties.getContextSetting();
-        assertEquals(ContextSetting.PER_REQUEST_WITH_INSTRUMENTATION, contextSetting);
+        assertThat(contextSetting).isEqualTo(ContextSetting.PER_REQUEST_WITH_INSTRUMENTATION);
     }
 }

--- a/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/spring/web/boot/test/AbstractAutoConfigurationTest.java
+++ b/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/spring/web/boot/test/AbstractAutoConfigurationTest.java
@@ -1,6 +1,6 @@
 package graphql.kickstart.spring.web.boot.test;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -36,7 +36,7 @@ public abstract class AbstractAutoConfigurationTest {
         this.autoConfiguration = autoConfiguration;
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (this.context != null) {
             this.context.close();

--- a/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/spring/web/boot/test/GraphQLServletPropertiesTest.java
+++ b/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/spring/web/boot/test/GraphQLServletPropertiesTest.java
@@ -1,10 +1,9 @@
 package graphql.kickstart.spring.web.boot.test;
 
 import graphql.kickstart.spring.web.boot.GraphQLServletProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Andrew Potter
@@ -31,13 +30,17 @@ public class GraphQLServletPropertiesTest {
         GraphQLServletProperties servletProperties = new GraphQLServletProperties();
         servletProperties.setMapping(mapping);
 
-        assertEquals(String.format("Expected mapping '%s' to return cors mapping '%s'", mapping, expected), servletProperties.getCorsMapping(), expected);
+        assertThat(servletProperties.getCorsMapping())
+            .as(String.format("Expected mapping '%s' to return cors mapping '%s'", mapping, expected))
+            .isEqualTo(expected);
     }
 
     private void verifyServletMapping(String mapping, String expected) {
         GraphQLServletProperties servletProperties = new GraphQLServletProperties();
         servletProperties.setMapping(mapping);
 
-        assertEquals(String.format("Expected mapping '%s' to return servlet mapping '%s'", mapping, expected), servletProperties.getServletMapping(), expected);
+        assertThat(servletProperties.getServletMapping())
+            .as(String.format("Expected mapping '%s' to return servlet mapping '%s'", mapping, expected))
+            .isEqualTo(expected);
     }
 }

--- a/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/spring/web/boot/test/instrumentation/GraphQLInstrumentationAutoConfigurationTest.java
+++ b/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/spring/web/boot/test/instrumentation/GraphQLInstrumentationAutoConfigurationTest.java
@@ -12,12 +12,14 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Marcel Overdijk
@@ -43,88 +45,94 @@ public class GraphQLInstrumentationAutoConfigurationTest extends AbstractAutoCon
 
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test
     public void noDefaultInstrumentations() {
         load(DefaultConfiguration.class);
 
-        this.getContext().getBean(Instrumentation.class);
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+            .isThrownBy(() -> this.getContext().getBean(Instrumentation.class));
     }
 
     @Test
     public void tracingInstrumentationEnabled() {
         load(DefaultConfiguration.class, "graphql.servlet.tracing-enabled=true");
 
-        Assert.assertNotNull(this.getContext().getBean(TracingInstrumentation.class));
+        assertThat(this.getContext().getBean(TracingInstrumentation.class)).isNotNull();
     }
 
     @Test
     public void maxQueryComplexityEnabled() {
         load(DefaultConfiguration.class, "graphql.servlet.maxQueryComplexity=10");
 
-        Assert.assertNotNull(this.getContext().getBean(MaxQueryComplexityInstrumentation.class));
+        assertThat(this.getContext().getBean(MaxQueryComplexityInstrumentation.class)).isNotNull();
     }
 
     @Test
     public void maxQueryDepthEnabled() {
         load(DefaultConfiguration.class, "graphql.servlet.maxQueryDepth=10");
 
-        Assert.assertNotNull(this.getContext().getBean(MaxQueryDepthInstrumentation.class));
+        assertThat(this.getContext().getBean(MaxQueryDepthInstrumentation.class)).isNotNull();
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test
     public void actuatorMetricsEnabledAndTracingEnabled() {
         load(DefaultConfiguration.class, "graphql.servlet.tracing-enabled=true", "graphql.servlet.actuator-metrics=true");
 
-        Assert.assertNotNull(this.getContext().getBean(TracingInstrumentation.class));
-        Assert.assertNotNull(this.getContext().getBean(MetricsInstrumentation.class));
-        this.getContext().getBean(TracingNoResolversInstrumentation.class);
+        assertThat(this.getContext().getBean(MetricsInstrumentation.class)).isNotNull();
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+            .isThrownBy(() -> this.getContext().getBean(TracingNoResolversInstrumentation.class));
     }
 
     @Test
     public void tracingInstrumentationDisabledAndMetricsEnabled() {
         load(DefaultConfiguration.class, "graphql.servlet.tracing-enabled=false", "graphql.servlet.actuator-metrics=true");
 
-        Assert.assertNotNull(this.getContext().getBean(MetricsInstrumentation.class));
-        Assert.assertNotNull(this.getContext().getBean(TracingNoResolversInstrumentation.class));
+        assertThat(this.getContext().getBean(MetricsInstrumentation.class)).isNotNull();
+        assertThat(this.getContext().getBean(TracingNoResolversInstrumentation.class)).isNotNull();
     }
 
     @Test
     public void tracingMetricsWithTracingDisabled() {
         load(DefaultConfiguration.class, "graphql.servlet.tracing-enabled='metrics-only'", "graphql.servlet.actuator-metrics=true");
 
-        Assert.assertNotNull(this.getContext().getBean("metricsInstrumentation"));
-        Assert.assertNotNull(this.getContext().getBean("tracingInstrumentation"));
+        assertThat(this.getContext().getBean("metricsInstrumentation")).isNotNull();
+        assertThat(this.getContext().getBean("tracingInstrumentation")).isNotNull();
     }
 
     @Test
     public void actuatorMetricsEnabled() {
         load(DefaultConfiguration.class, "graphql.servlet.actuator-metrics=true");
 
-        Assert.assertNotNull(this.getContext().getBean(MetricsInstrumentation.class));
-        Assert.assertNotNull(this.getContext().getBean(TracingNoResolversInstrumentation.class));
+        assertThat(this.getContext().getBean(MetricsInstrumentation.class)).isNotNull();
+        assertThat(this.getContext().getBean(TracingNoResolversInstrumentation.class)).isNotNull();
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test
     public void tracingInstrumentationEnabledAndMetricsDisabled() {
         load(DefaultConfiguration.class, "graphql.servlet.tracing-enabled=true", "graphql.servlet.actuator-metrics=false");
 
-        Assert.assertNotNull(this.getContext().getBean(TracingInstrumentation.class));
-        this.getContext().getBean(MetricsInstrumentation.class);
+        assertThat(this.getContext().getBean(TracingInstrumentation.class)).isNotNull();
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+            .isThrownBy(() -> this.getContext().getBean(MetricsInstrumentation.class));
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test
     public void tracingInstrumentationDisabledAndMetricsDisabled() {
         load(DefaultConfiguration.class, "graphql.servlet.tracing-enabled=false", "graphql.servlet.actuator-metrics=false");
 
-        this.getContext().getBean(MetricsInstrumentation.class);
-        this.getContext().getBean(TracingNoResolversInstrumentation.class);
-        this.getContext().getBean(TracingInstrumentation.class);
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+            .isThrownBy(() -> this.getContext().getBean(MetricsInstrumentation.class));
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+            .isThrownBy(() ->this.getContext().getBean(TracingNoResolversInstrumentation.class));
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+            .isThrownBy(() ->this.getContext().getBean(TracingInstrumentation.class));
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test
     public void actuatorMetricsDisabled() {
         load(DefaultConfiguration.class, "graphql.servlet.actuator-metrics=false");
 
-        this.getContext().getBean(MetricsInstrumentation.class);
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+            .isThrownBy(() ->this.getContext().getBean(MetricsInstrumentation.class));
     }
 }

--- a/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/spring/web/boot/test/web/GraphQLWebAutoConfigurationTest.java
+++ b/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/spring/web/boot/test/web/GraphQLWebAutoConfigurationTest.java
@@ -12,11 +12,12 @@ import graphql.execution.ExecutionStrategy;
 import graphql.execution.instrumentation.tracing.TracingInstrumentation;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author <a href="mailto:java.lang.RuntimeException@gmail.com">oEmbedler Inc.</a>
@@ -34,56 +35,56 @@ public class GraphQLWebAutoConfigurationTest extends AbstractAutoConfigurationTe
   public void appContextLoadsWithNoExecutionStrategy() {
     load(SimpleConfiguration.class);
 
-    Assert.assertNotNull(this.getContext().getBean(AbstractGraphQLHttpServlet.class));
+    assertThat(this.getContext().getBean(AbstractGraphQLHttpServlet.class)).isNotNull();
   }
 
   @Test
   public void appContextLoadsWithOneExecutionStrategy() {
     load(OneExecutionStrategy.class);
 
-    Assert.assertNotNull(this.getContext().getBean(AbstractGraphQLHttpServlet.class));
+    assertThat(this.getContext().getBean(AbstractGraphQLHttpServlet.class)).isNotNull();
   }
 
   @Test
   public void appContextLoadsWithTwoExecutionStrategies() {
     load(TwoExecutionStrategies.class);
 
-    Assert.assertNotNull(this.getContext().getBean(AbstractGraphQLHttpServlet.class));
+    assertThat(this.getContext().getBean(AbstractGraphQLHttpServlet.class)).isNotNull();
   }
 
   @Test
   public void appContextLoadsWithThreeExecutionStrategies() {
     load(ThreeExecutionStrategies.class);
 
-    Assert.assertNotNull(this.getContext().getBean(AbstractGraphQLHttpServlet.class));
+    assertThat(this.getContext().getBean(AbstractGraphQLHttpServlet.class)).isNotNull();
   }
 
   @Test
   public void appContextLoadsWithNoInstrumentation() {
     load(SimpleConfiguration.class);
 
-    Assert.assertNotNull(this.getContext().getBean(AbstractGraphQLHttpServlet.class));
+    assertThat(this.getContext().getBean(AbstractGraphQLHttpServlet.class)).isNotNull();
   }
 
   @Test
   public void appContextLoadsWithOneInstrumentation() {
     load(OneInstrumentationConfiguration.class);
 
-    Assert.assertNotNull(this.getContext().getBean(AbstractGraphQLHttpServlet.class));
+    assertThat(this.getContext().getBean(AbstractGraphQLHttpServlet.class)).isNotNull();
   }
 
   @Test
   public void appContextLoadsWithMultipleInstrumentations() {
     load(MultipleInstrumentationsConfiguration.class);
 
-    Assert.assertNotNull(this.getContext().getBean(AbstractGraphQLHttpServlet.class));
+    assertThat(this.getContext().getBean(AbstractGraphQLHttpServlet.class)).isNotNull();
   }
 
   @Test
   public void appContextLoadsWithCustomSchemaProvider() {
     load(SchemaProviderConfiguration.class);
 
-    Assert.assertNotNull(this.getContext().getBean(AbstractGraphQLHttpServlet.class));
+    assertThat(this.getContext().getBean(AbstractGraphQLHttpServlet.class)).isNotNull();
   }
 
   @Configuration

--- a/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundCSRFTest.java
+++ b/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundCSRFTest.java
@@ -1,13 +1,13 @@
 package graphql.kickstart.playground.boot;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.web.csrf.CsrfToken;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -16,7 +16,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = PlaygroundTestConfig.class)
 @AutoConfigureMockMvc
 public class PlaygroundCSRFTest {

--- a/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundCdnCustomVersionTest.java
+++ b/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundCdnCustomVersionTest.java
@@ -1,13 +1,13 @@
 package graphql.kickstart.playground.boot;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = PlaygroundTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application-playground-cdn-custom-version-test.properties")

--- a/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundCdnTest.java
+++ b/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundCdnTest.java
@@ -1,13 +1,14 @@
 package graphql.kickstart.playground.boot;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = PlaygroundTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application-playground-cdn-test.properties")

--- a/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundCustomMappingTest.java
+++ b/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundCustomMappingTest.java
@@ -1,13 +1,13 @@
 package graphql.kickstart.playground.boot;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.nio.charset.StandardCharsets;
@@ -18,7 +18,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = PlaygroundTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application-playground-mapping-test.properties")

--- a/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundCustomStaticPathTest.java
+++ b/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundCustomStaticPathTest.java
@@ -1,13 +1,14 @@
 package graphql.kickstart.playground.boot;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = PlaygroundTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application-playground-custom-static-path.properties")

--- a/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundCustomTitleTest.java
+++ b/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundCustomTitleTest.java
@@ -2,13 +2,13 @@ package graphql.kickstart.playground.boot;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -16,7 +16,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = PlaygroundTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application-playground-custom-title.properties")

--- a/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundDisabledTest.java
+++ b/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundDisabledTest.java
@@ -1,19 +1,20 @@
 package graphql.kickstart.playground.boot;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = PlaygroundTestConfig.class, properties = "graphql.playground.enabled=false")
 @AutoConfigureMockMvc
 public class PlaygroundDisabledTest {
@@ -24,9 +25,10 @@ public class PlaygroundDisabledTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test
     public void playgroundShouldNotLoadIfDisabled() {
-        applicationContext.getBean(PlaygroundController.class);
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+            .isThrownBy(() -> applicationContext.getBean(PlaygroundController.class));
     }
 
     @Test

--- a/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundEnabledTest.java
+++ b/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundEnabledTest.java
@@ -3,26 +3,27 @@ package graphql.kickstart.playground.boot;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.hamcrest.Matchers.isEmptyString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = PlaygroundTestConfig.class)
 @AutoConfigureMockMvc
 public class PlaygroundEnabledTest {
@@ -52,7 +53,7 @@ public class PlaygroundEnabledTest {
         final MvcResult mvcResult = mockMvc.perform(get(PlaygroundTestHelper.DEFAULT_PLAYGROUND_ENDPOINT))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(content().string(not(isEmptyString())))
+                .andExpect(content().string(not(is(emptyString()))))
                 .andExpect(model().attribute(PlaygroundTestHelper.PAGE_TITLE_FIELD_NAME, DEFAULT_TITLE))
                 .andExpect(model().attribute(PlaygroundTestHelper.CSS_URL_FIELD_NAME, DEFAULT_CSS_PATH))
                 .andExpect(model().attribute(PlaygroundTestHelper.SCRIPT_URL_FIELD_NAME, DEFAULT_SCRIPT_PATH))
@@ -69,7 +70,7 @@ public class PlaygroundEnabledTest {
     public void defaultCssShouldBeAvailable() throws Exception {
         mockMvc.perform(get(DEFAULT_CSS_PATH))
                 .andExpect(status().isOk())
-                .andExpect(content().string(not(isEmptyString())))
+                .andExpect(content().string(not(is(emptyString()))))
                 .andExpect(content().contentTypeCompatibleWith("text/css"));
     }
 
@@ -77,7 +78,7 @@ public class PlaygroundEnabledTest {
     public void defaultScriptShouldBeAvailable() throws Exception {
         mockMvc.perform(get(DEFAULT_SCRIPT_PATH))
                 .andExpect(status().isOk())
-                .andExpect(content().string(not(isEmptyString())))
+                .andExpect(content().string(not(is(emptyString()))))
                 .andExpect(content().contentTypeCompatibleWith("application/javascript"));
     }
 
@@ -85,7 +86,7 @@ public class PlaygroundEnabledTest {
     public void defaultFaviconShouldBeAvailable() throws Exception {
         mockMvc.perform(get(DEFAULT_FAVICON_PATH))
                 .andExpect(status().isOk())
-                .andExpect(content().string(not(isEmptyString())))
+                .andExpect(content().string(not(is(emptyString()))))
                 .andExpect(content().contentTypeCompatibleWith("image/png"));
     }
 
@@ -93,7 +94,7 @@ public class PlaygroundEnabledTest {
     public void defaultLogoShouldBeAvailable() throws Exception {
         mockMvc.perform(get(DEFAULT_LOGO_PATH))
                 .andExpect(status().isOk())
-                .andExpect(content().string(not(isEmptyString())))
+                .andExpect(content().string(not(is(emptyString()))))
                 .andExpect(content().contentTypeCompatibleWith("image/png"));
     }
 }

--- a/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundSettingsTest.java
+++ b/playground-spring-boot-autoconfigure/src/test/java/graphql/kickstart/playground/boot/PlaygroundSettingsTest.java
@@ -3,12 +3,13 @@ package graphql.kickstart.playground.boot;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -16,7 +17,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = PlaygroundTestConfig.class)
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:application-playground-settings-test.properties")

--- a/voyager-spring-boot-autoconfigure/src/test/java/graphql/kickstart/voyager/boot/test/AbstractAutoConfigurationTest.java
+++ b/voyager-spring-boot-autoconfigure/src/test/java/graphql/kickstart/voyager/boot/test/AbstractAutoConfigurationTest.java
@@ -1,6 +1,6 @@
 package graphql.kickstart.voyager.boot.test;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigRegistry;
 import org.springframework.context.support.AbstractApplicationContext;
@@ -25,7 +25,7 @@ public abstract class AbstractAutoConfigurationTest {
         this.autoConfiguration = autoConfiguration;
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (this.context != null) {
             this.context.close();

--- a/voyager-spring-boot-autoconfigure/src/test/java/graphql/kickstart/voyager/boot/test/ReactiveVoyagerControllerTest.java
+++ b/voyager-spring-boot-autoconfigure/src/test/java/graphql/kickstart/voyager/boot/test/ReactiveVoyagerControllerTest.java
@@ -2,14 +2,16 @@ package graphql.kickstart.voyager.boot.test;
 
 import graphql.kickstart.voyager.boot.ReactiveVoyagerAutoConfiguration;
 import graphql.kickstart.voyager.boot.ReactiveVoyagerController;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.web.reactive.context.AnnotationConfigReactiveWebApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Max Günther
@@ -42,13 +44,14 @@ public class ReactiveVoyagerControllerTest extends AbstractAutoConfigurationTest
     public void voyagerLoads() {
         load(EnabledConfiguration.class);
 
-        Assert.assertNotNull(this.getContext().getBean(ReactiveVoyagerController.class));
+        assertThat(this.getContext().getBean(ReactiveVoyagerController.class)).isNotNull();
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test
     public void voyagerDoesNotLoad() {
         load(DisabledConfiguration.class);
 
-        this.getContext().getBean(ReactiveVoyagerController.class);
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+            .isThrownBy(() -> this.getContext().getBean(ReactiveVoyagerController.class));
     }
 }

--- a/voyager-spring-boot-autoconfigure/src/test/java/graphql/kickstart/voyager/boot/test/VoyagerControllerTest.java
+++ b/voyager-spring-boot-autoconfigure/src/test/java/graphql/kickstart/voyager/boot/test/VoyagerControllerTest.java
@@ -2,14 +2,16 @@ package graphql.kickstart.voyager.boot.test;
 
 import graphql.kickstart.voyager.boot.VoyagerAutoConfiguration;
 import graphql.kickstart.voyager.boot.VoyagerController;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Andrew Potter
@@ -42,13 +44,14 @@ public class VoyagerControllerTest extends AbstractAutoConfigurationTest {
     public void graphiqlLoads() {
         load(EnabledConfiguration.class);
 
-        Assert.assertNotNull(this.getContext().getBean(VoyagerController.class));
+        assertThat(this.getContext().getBean(VoyagerController.class)).isNotNull();
     }
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test
     public void graphiqlDoesNotLoad() {
         load(DisabledConfiguration.class);
 
-        this.getContext().getBean(VoyagerController.class);
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+            .isThrownBy(() -> this.getContext().getBean(VoyagerController.class));
     }
 }


### PR DESCRIPTION
This is required for Spring 2.4.0, since it removed JUnit4 support.