### PR TITLE
[fixes #426] made GraphQLSpringServerWebExchangeContext public 

### DIFF
--- a/graphql-kickstart-spring-webflux/src/main/java/graphql/kickstart/spring/webflux/GraphQLSpringWebSocketSessionContext.java
+++ b/graphql-kickstart-spring-webflux/src/main/java/graphql/kickstart/spring/webflux/GraphQLSpringWebSocketSessionContext.java
@@ -3,7 +3,7 @@ package graphql.kickstart.spring.webflux;
 import graphql.kickstart.execution.context.GraphQLContext;
 import org.springframework.web.reactive.socket.WebSocketSession;
 
-interface GraphQLSpringWebSocketSessionContext extends GraphQLContext {
+public interface GraphQLSpringWebSocketSessionContext extends GraphQLContext {
 
   WebSocketSession getWebSocketSession();
 


### PR DESCRIPTION
made GraphQLSpringServerWebExchangeContext public rather than internal so that it can be referenced by dependent projects

fixes #426