### PR TITLE
ci: allow successful build on master branches of forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       - name: Gradle Publish Snapshot
+        if: env.BINTRAY_USER != 'SKIP_BINTRAY_PUBLISH'
         env:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_PASS: ${{ secrets.BINTRAY_PASSWORD }}


### PR DESCRIPTION
By setting BINTRAY_USER to SKIP_BINTRAY_PUBLISH, it is possible now to disable the snapshot publishing job, allowing master branches of forks to successfully pass the ci.