### PR TITLE
feat: make graphql-java-extended-scalars dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,12 @@ The available scalars are the following: `BigDecimal`, `BigInteger`, `Byte`, `Ch
 `Locale`, `Long`, `NegativeFloat`, `NegativeInt`, `NonNegativeFloat`, `NonNegativeInt`, `NonPositiveFloat`, 
 `NonPositiveInt`, `Object`, `PositiveFloat`, `PositiveInt`, `Short`, `Time`, `Url`.
 
+The `graphql-java-extended-scalars` dependency must be added to the project, e. g.:
+
+```groovy
+implementation "com.graphql-java:graphql-java-extended-scalars:16.0.0"
+```
+
 This setting works with both the [GraphQL Java Tools](#graphql-java-tools) and the
 [GraphQL Annotations](#graphql-annotations) integration.
 

--- a/example-graphql-subscription/build.gradle
+++ b/example-graphql-subscription/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation(project(":graphql-spring-boot-starter"))
     implementation(project(":graphiql-spring-boot-starter"))
     implementation "com.graphql-java-kickstart:graphql-java-tools:$LIB_GRAPHQL_JAVA_TOOLS_VER"
+    implementation "com.graphql-java:graphql-java-extended-scalars:$LIB_EXTENDED_SCALARS_VERSION"
 
     implementation "io.reactivex.rxjava2:rxjava"
     implementation "io.projectreactor:reactor-core"

--- a/example-graphql-subscription/src/test/java/graphql/kickstart/spring/web/boot/test/SmokeTest.java
+++ b/example-graphql-subscription/src/test/java/graphql/kickstart/spring/web/boot/test/SmokeTest.java
@@ -1,0 +1,16 @@
+package graphql.kickstart.spring.web.boot.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("Basic smoke test")
+public class SmokeTest {
+
+    @Test
+    @DisplayName("Ensure that Spring context loads successfully.")
+    void contextLoads() {
+
+    }
+}

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 
 jar.enabled = false

--- a/example/src/test/java/graphql/kickstart/spring/web/boot/sample/test/SmokeTest.java
+++ b/example/src/test/java/graphql/kickstart/spring/web/boot/sample/test/SmokeTest.java
@@ -1,0 +1,16 @@
+package graphql.kickstart.spring.web.boot.sample.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("Basic smoke test")
+public class SmokeTest {
+
+    @Test
+    @DisplayName("Ensure that Spring context loads successfully.")
+    void contextLoads() {
+
+    }
+}

--- a/graphql-spring-boot-autoconfigure/build.gradle
+++ b/graphql-spring-boot-autoconfigure/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     api(project(":graphql-kickstart-spring-boot-starter-tools"))
     api(project(":graphql-kickstart-spring-support"))
     implementation "org.springframework.boot:spring-boot-autoconfigure"
-    api "com.graphql-java:graphql-java-extended-scalars:$LIB_EXTENDED_SCALARS_VERSION"
     api "com.graphql-java-kickstart:graphql-java-kickstart:$LIB_GRAPHQL_SERVLET_VER"
     api "com.graphql-java-kickstart:graphql-java-servlet:$LIB_GRAPHQL_SERVLET_VER"
     api "com.graphql-java:graphql-java:$LIB_GRAPHQL_JAVA_VER"
@@ -35,6 +34,7 @@ dependencies {
     compileOnly "org.springframework.boot:spring-boot-starter-web"
 
     testImplementation "com.graphql-java:graphql-java:$LIB_GRAPHQL_JAVA_VER"
+    testImplementation "com.graphql-java:graphql-java-extended-scalars:$LIB_EXTENDED_SCALARS_VERSION"
     testImplementation "org.springframework.boot:spring-boot-starter-web"
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     testImplementation(project(":graphql-spring-boot-test"))


### PR DESCRIPTION
The dependency is no longer included automatically. Instead, the user of the library can decide whether this is needed or not.

Application startup will fail if com.graphql-java:graphql-java-extended-scalars is missing and there are extended scalars specified in the graphql.extended-scalars configuration property.

The primary incentive for this change was that com.graphql-java:graphql-java-extended-scalars 16.0.0 is not available from Maven Central (https://github.com/graphql-java/graphql-java-extended-scalars/issues/38), and including it automatically would enforce users of this library to use JCenter too.

An additional benefit is that if not used, it is not added to the classpath unnecessarily. 