### PR TITLE
Only call GraphqlErrorBuilder with non-null data

### DIFF
--- a/graphql-kickstart-spring-support/src/main/java/graphql/kickstart/spring/error/GraphQLErrorFromExceptionHandler.java
+++ b/graphql-kickstart-spring-support/src/main/java/graphql/kickstart/spring/error/GraphQLErrorFromExceptionHandler.java
@@ -71,15 +71,13 @@ class GraphQLErrorFromExceptionHandler extends DefaultGraphQLErrorHandler {
     Map<String, Object> extensions = Optional.ofNullable(errorContext.getExtensions())
         .orElseGet(HashMap::new);
     extensions.put("type", throwable.getClass().getSimpleName());
-    return singletonList(
-        GraphqlErrorBuilder.newError()
-            .message(throwable.getMessage())
-            .errorType(errorContext.getErrorType())
-            .locations(errorContext.getLocations())
-            .path(errorContext.getPath())
-            .extensions(extensions)
-            .build()
-    );
+    GraphqlErrorBuilder builder = GraphqlErrorBuilder.newError()
+        .extensions(extensions);
+    Optional.ofNullable(throwable.getMessage()).ifPresent(builder::message);
+    Optional.ofNullable(errorContext.getErrorType()).ifPresent(builder::errorType);
+    Optional.ofNullable(errorContext.getLocations()).ifPresent(builder::locations);
+    Optional.ofNullable(errorContext.getPath()).ifPresent(builder::path);
+    return singletonList(builder.build());
   }
 
 }

--- a/graphql-kickstart-spring-support/src/test/java/graphql/kickstart/spring/error/GraphQLErrorFromExceptionHandlerTest.java
+++ b/graphql-kickstart-spring-support/src/test/java/graphql/kickstart/spring/error/GraphQLErrorFromExceptionHandlerTest.java
@@ -4,6 +4,7 @@ import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphqlErrorException;
 import graphql.language.SourceLocation;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -12,19 +13,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class GraphQLErrorFromExceptionHandlerTest {
   @Test
   void allows_errors_with_null_path() {
-    GraphQLErrorFromExceptionHandler sut = new GraphQLErrorFromExceptionHandler(List.of());
+    GraphQLErrorFromExceptionHandler sut = new GraphQLErrorFromExceptionHandler(new ArrayList<>());
 
-    List<GraphQLError> errors = List.of(
-        GraphqlErrorException.newErrorException()
-            .message("Error without a path")
-            .sourceLocation(new SourceLocation(0, 0))
-            .build(),
-        GraphqlErrorException.newErrorException()
-            .message("Error with path")
-            .sourceLocation(new SourceLocation(0, 0))
-            .errorClassification(ErrorType.ValidationError)
-            .path(List.of())
-            .build());
+    List<GraphQLError> errors = new ArrayList<>();
+    errors.add(GraphqlErrorException.newErrorException()
+        .message("Error without a path")
+        .sourceLocation(new SourceLocation(0, 0))
+        .build());
+    errors.add(GraphqlErrorException.newErrorException()
+        .message("Error with path")
+        .sourceLocation(new SourceLocation(0, 0))
+        .errorClassification(ErrorType.ValidationError)
+        .path(new ArrayList<>())
+        .build());
+
     List<GraphQLError> processedErrors = sut.filterGraphQLErrors(errors);
 
     for (int i = 0; i < errors.size(); i++) {

--- a/graphql-kickstart-spring-support/src/test/java/graphql/kickstart/spring/error/GraphQLErrorFromExceptionHandlerTest.java
+++ b/graphql-kickstart-spring-support/src/test/java/graphql/kickstart/spring/error/GraphQLErrorFromExceptionHandlerTest.java
@@ -1,0 +1,39 @@
+package graphql.kickstart.spring.error;
+
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorException;
+import graphql.language.SourceLocation;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GraphQLErrorFromExceptionHandlerTest {
+  @Test
+  void allows_errors_with_null_path() {
+    GraphQLErrorFromExceptionHandler sut = new GraphQLErrorFromExceptionHandler(List.of());
+
+    List<GraphQLError> errors = List.of(
+        GraphqlErrorException.newErrorException()
+            .message("Error without a path")
+            .sourceLocation(new SourceLocation(0, 0))
+            .build(),
+        GraphqlErrorException.newErrorException()
+            .message("Error with path")
+            .sourceLocation(new SourceLocation(0, 0))
+            .errorClassification(ErrorType.ValidationError)
+            .path(List.of())
+            .build());
+    List<GraphQLError> processedErrors = sut.filterGraphQLErrors(errors);
+
+    for (int i = 0; i < errors.size(); i++) {
+      GraphQLError error = errors.get(i);
+      GraphQLError processedError = processedErrors.get(i);
+      assertEquals(error.getMessage(), processedError.getMessage());
+      assertEquals(error.getErrorType(), processedError.getErrorType());
+      assertEquals(error.getLocations(), processedError.getLocations());
+      assertEquals(error.getPath(), processedError.getPath());
+    }
+  }
+}


### PR DESCRIPTION
The methods on GraphqlErrorBuilder each contain [an assertion that the supplied data is non-null](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/GraphqlErrorBuilder.java#L77), but it is not required that these elements be non-null on every throw GraphQLError. For example, errors often omit a `path` property, which will lead to an unhandled `graphql.AssertException` when the error is handled by `GraphQLErrorFromExceptionHandler.java`. 

At present, type coercion errors always result in a HTTP response with an empty body and a 400 response code due to the way graphql-java [normalizes `CoercingParseValueException`s](https://github.com/graphql-java/graphql-java/blob/v16.2/src/main/java/graphql/execution/ValuesResolver.java#L173)