### PR TITLE
fix: test subscription not waiting the specified amount of time

### DIFF
--- a/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestSubscription.java
+++ b/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestSubscription.java
@@ -300,9 +300,17 @@ public class GraphQLTestSubscription {
       fail("Subscription already stopped. Forgot to call reset after test case?");
     }
 
-    await()
-        .atMost(timeout, TimeUnit.MILLISECONDS)
-        .until(() -> state.getResponses().size() >= numExpectedResponses);
+    if (numExpectedResponses > 0) {
+      await()
+          .atMost(timeout, TimeUnit.MILLISECONDS)
+          .until(() -> state.getResponses().size() >= numExpectedResponses);
+    } else {
+      try {
+        Thread.sleep(timeout);
+      } catch (InterruptedException e) {
+        fail("Unable to wait the specified amount of time.", e);
+      }
+    }
 
     if (stopAfter) {
       stop();

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLSubscriptionTestAwaitNoAnswerTest.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLSubscriptionTestAwaitNoAnswerTest.java
@@ -7,17 +7,23 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.Instant;
+
 @DisplayName("Testing awaitNoResponse methods")
 class GraphQLSubscriptionTestAwaitNoAnswerTest extends GraphQLTestSubscriptionTestBase {
 
   @Test
   @DisplayName("Should succeed if no responses arrived / default stopAfter.")
   void shouldAwaitNoResponseSucceedIfNoResponsesArrivedDefaultStopAfter() {
-    // WHEN - THEN
+    // GIVEN
+    final Instant timeBeforeTestStart = Instant.now();
+    // WHEN
     graphQLTestSubscription
         .start(SUBSCRIPTION_THAT_TIMES_OUT_RESOURCE)
         .waitAndExpectNoResponse(TIMEOUT);
+    // THEN
     assertThatSubscriptionWasStopped();
+    assertThatMinimumRequiredTimeElapsedSince(timeBeforeTestStart);
   }
 
   @ParameterizedTest
@@ -26,20 +32,25 @@ class GraphQLSubscriptionTestAwaitNoAnswerTest extends GraphQLTestSubscriptionTe
   void shouldAwaitNoResponseSucceedIfNoResponsesArrived(
       final boolean stopAfter
   ) {
-    // WHEN - THEN
+    // GIVEN
+    final Instant timeBeforeTestStart = Instant.now();
+    // WHEN
     graphQLTestSubscription
         .start(SUBSCRIPTION_THAT_TIMES_OUT_RESOURCE)
         .waitAndExpectNoResponse(TIMEOUT, stopAfter);
+    // THEN
     assertThatSubscriptionStoppedStatusIs(stopAfter);
+    assertThatMinimumRequiredTimeElapsedSince(timeBeforeTestStart);
   }
 
   @Test
   @DisplayName("Should raise assertion error if any response arrived / default stop after.")
   void shouldRaiseAssertionErrorIfResponseArrivedDefaultStopAfter() {
-    // WHEN - THEN
+    // WHEN
     graphQLTestSubscription.start(TIMER_SUBSCRIPTION_RESOURCE);
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> graphQLTestSubscription
-        .waitAndExpectNoResponse(TIMEOUT));
+    // THEN
+    assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> graphQLTestSubscription.waitAndExpectNoResponse(TIMEOUT));
     assertThatSubscriptionWasStopped();
   }
 
@@ -49,10 +60,11 @@ class GraphQLSubscriptionTestAwaitNoAnswerTest extends GraphQLTestSubscriptionTe
   void shouldRaiseAssertionErrorIfResponseArrived(
       final boolean stopAfter
   ) {
-    // WHEN - THEN
+    // WHEN
     graphQLTestSubscription.start(TIMER_SUBSCRIPTION_RESOURCE);
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> graphQLTestSubscription
-        .waitAndExpectNoResponse(TIMEOUT, stopAfter));
+    // THEN
+    assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> graphQLTestSubscription.waitAndExpectNoResponse(TIMEOUT, stopAfter));
     assertThatSubscriptionStoppedStatusIs(stopAfter);
   }
 }

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionAwaitAndGetResponseTest.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionAwaitAndGetResponseTest.java
@@ -2,6 +2,7 @@ package com.graphql.spring.boot.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,8 @@ class GraphQLTestSubscriptionAwaitAndGetResponseTest extends
   @Test
   @DisplayName("Should await and get all responses / default stopAfter.")
   void shouldAwaitAndGetAllResponsesDefaultStopAfter() {
+    // GIVEN
+    final Instant timeBeforeTest = Instant.now();
     // WHEN
     final List<GraphQLResponse> graphQLResponses = graphQLTestSubscription
         .start(TIMER_SUBSCRIPTION_RESOURCE)
@@ -52,6 +55,7 @@ class GraphQLTestSubscriptionAwaitAndGetResponseTest extends
         .extracting(response -> response.get(DATA_TIMER_FIELD, Long.class))
         .containsExactly(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
     assertThatSubscriptionWasStopped();
+    assertThatMinimumRequiredTimeElapsedSince(timeBeforeTest);
   }
 
   @ParameterizedTest
@@ -60,6 +64,8 @@ class GraphQLTestSubscriptionAwaitAndGetResponseTest extends
   void shouldAwaitAndGetAllResponses(
       final boolean stopAfter
   ) {
+    // GIVEN
+    final Instant timeBeforeTest = Instant.now();
     // WHEN
     final List<GraphQLResponse> graphQLResponses = graphQLTestSubscription
         .start(TIMER_SUBSCRIPTION_RESOURCE)
@@ -69,6 +75,7 @@ class GraphQLTestSubscriptionAwaitAndGetResponseTest extends
         .extracting(response -> response.get(DATA_TIMER_FIELD, Long.class))
         .containsExactly(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
     assertThatSubscriptionStoppedStatusIs(stopAfter);
+    assertThatMinimumRequiredTimeElapsedSince(timeBeforeTest);
   }
 
   @Test

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionTestBase.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestSubscriptionTestBase.java
@@ -5,11 +5,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.env.Environment;
 
+import java.time.Duration;
+import java.time.Instant;
+
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Timeout(60)
 public class GraphQLTestSubscriptionTestBase {
 
   protected static final String TIMER_SUBSCRIPTION_RESOURCE = "timer-subscription-resource.graphql";
@@ -62,5 +67,11 @@ public class GraphQLTestSubscriptionTestBase {
     assertThat(graphQLTestSubscription.isStopped())
         .as("Subscription should not be stopped.")
         .isFalse();
+  }
+
+  protected void assertThatMinimumRequiredTimeElapsedSince(final Instant timeBeforeTestStart) {
+    assertThat(Duration.between(timeBeforeTestStart, Instant.now()))
+        .as("Should wait the specified amount of time")
+        .isGreaterThanOrEqualTo(Duration.ofMillis(TIMEOUT));
   }
 }


### PR DESCRIPTION
If `numExpectedResponses `was 0 or negative, the method did not work according to documentation, it did not wait out the specified amount of time as the condition in await() was fulfilled immediately.

This resulted in `waitAndExpectNoResponse` and  `awaitAndGetAllResponses` not working as specified in the documentation.

The test suite was also updated to catch this issue in the future.