### PR TITLE
Setting renovate config file to run on forks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "includeForks" : true
+}


### PR DESCRIPTION
Manually configure `graphql-spring-boot` because its based off a fork