### PR TITLE
Allow successful CI workflow runs on master branch of forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       - name: Gradle Publish Snapshot
-        if: env.BINTRAY_USER != 'SKIP_BINTRAY_PUBLISH'
+        if: env.BINTRAY_USER != 'SKIP_BINTRAY_PUBLISH' && env.BINTRAY_USER != null
         env:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_PASS: ${{ secrets.BINTRAY_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,4 +96,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: env.SONAR_TOKEN != null
         run: ./gradlew build jacocoTestReport sonarqube --info


### PR DESCRIPTION
Sonar check will no longer run if SONAR_TOKEN is not provided. Also, Bintray publish will also be skipped if BINTRAY_USER  is null (formerly it was only skipped if explicitly set to SKIP_BINTRAY_PUBLISH in the secrets of the forked repository).