### PR TITLE
fix(dependencies): generate and publish proper pom file

### DIFF
--- a/graphql-spring-boot-dependencies/build.gradle
+++ b/graphql-spring-boot-dependencies/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
 publishing {
     publications {
-        mainProjectPublication(MavenPublication) {
+        mavenJava(MavenPublication) {
             from components.javaPlatform
         }
     }


### PR DESCRIPTION
Two files were generated, an empty` mavenJava/pom-default.xml` and a `mainProjectPublication/pom-default.xml` with proper content.

The published artifact used th empty from `mavenJava`.

This update fixes the issue by adding proper content to mavenJava.