### PR TITLE
fix: Memory leak when using reactive subscriptions with KeepAlive

### DIFF
--- a/graphql-kickstart-spring-webflux/src/main/java/graphql/kickstart/spring/webflux/ReactiveWebSocketSubscriptionSession.java
+++ b/graphql-kickstart-spring-webflux/src/main/java/graphql/kickstart/spring/webflux/ReactiveWebSocketSubscriptionSession.java
@@ -8,6 +8,7 @@ import org.springframework.web.reactive.socket.WebSocketSession;
 public class ReactiveWebSocketSubscriptionSession extends DefaultSubscriptionSession {
 
   private final WebSocketSession webSocketSession;
+  private boolean opened = true;
 
   public ReactiveWebSocketSubscriptionSession(
       GraphQLSubscriptionMapper mapper, WebSocketSession webSocketSession) {
@@ -17,7 +18,7 @@ public class ReactiveWebSocketSubscriptionSession extends DefaultSubscriptionSes
 
   @Override
   public boolean isOpen() {
-    return true;
+    return opened;
   }
 
   @Override
@@ -33,5 +34,11 @@ public class ReactiveWebSocketSubscriptionSession extends DefaultSubscriptionSes
   @Override
   public WebSocketSession unwrap() {
     return webSocketSession;
+  }
+
+  @Override
+  public void close(final String reason) {
+    super.close(reason);
+    this.opened = false;
   }
 }


### PR DESCRIPTION
Hi !

This PR should fix a memory leak when using webflux with subscriptions and KeepAlive.

### Explanation
**ApolloSubscriptionKeepAliveRunner** is responsible for sending keep alive messages through the websocket as long as the websocketSubscriptionSession is "opened". This runner, uses a scheduled Executor for this purpose.  
When a subscription is closed, of an exception occurs while sending message, KeepAlive message is not more scheduled and everything works fine.

**Bug** :
ReactiveWebSocketSubscriptionSession is the object representing a Reactive Subscription, this object always return `true`on the `isOpen`method, the keepAliveRunner will never stop sending messages, and stack references to dead subscriptions (Memory leak).  
No exception occurs while sending messages on a closed subscription, because we are just publishing to a Flux without subscribers. See ReactiveWebSocketSubscriptionsHandler.

A memory leak is also present on `SingleSubscriberPublisher` in graphql-java project as we keep adding data to the `ConcurrentLinkedDeque` even if there is no subscribers.

**Fix** : 
ReactiveWebSocketSubscriptionSession is now catching the call to `close` method to update the internal state of the websocket.