### PR TITLE
chore: update deprecated properties in jacoco test reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,9 +95,9 @@ subprojects {
 
         jacocoTestReport {
             reports {
-                xml.enabled = true
-                html.enabled = false
-                csv.enabled = false
+                xml.required = true
+                html.required = false
+                csv.required = false
             }
         }
 


### PR DESCRIPTION
"enabled" is replaced by "required"