### PR TITLE
fix: 'Invalid Syntax : offending token '<EOF>'' when using Apollo persisted queries

### DIFF
--- a/graphql-kickstart-spring-webflux/src/main/java/graphql/kickstart/spring/webflux/GraphQLController.java
+++ b/graphql-kickstart-spring-webflux/src/main/java/graphql/kickstart/spring/webflux/GraphQLController.java
@@ -33,10 +33,11 @@ public class GraphQLController extends AbstractGraphQLController {
       String query,
       String operationName,
       Map<String, Object> variables,
+      Map<String, Object> extensions,
       ServerWebExchange serverWebExchange) {
     GraphQLSingleInvocationInput invocationInput =
         invocationInputFactory.create(
-            new GraphQLRequest(query, variables, operationName), serverWebExchange);
+            new GraphQLRequest(query, variables, extensions, operationName), serverWebExchange);
     Mono<ExecutionResult> executionResult =
         Mono.fromCompletionStage(graphQLInvoker.executeAsync(invocationInput));
     return executionResult.map(objectMapper::createResultFromExecutionResult);


### PR DESCRIPTION
(reopening of https://github.com/graphql-java-kickstart/graphql-spring-boot/pull/653)
Hi, I've opened a pull request in https://github.com/graphql-java-kickstart/graphql-java-servlet as well, this fix depends on it. This pull request should fix the following issue:

When using Apollo persisted queries via angular-apollo I get the following error in browser console:
`Invalid Syntax : offending token '<EOF>'`

And the following in server console:
`notprivacysafe.graphql.GraphQL           : Query failed to parse : ''`

Minimal reproduction: https://github.com/ObeyYourMaster/graphql-kickstart-spring-boot-apq-not-working-showcase

My angular setup:

package.json
```javascript
{
  "@apollo/client": "3.3.20",
  "crypto-es": "1.2.7",
  "apollo-angular": "2.6.0"
}
```

ApolloClient setup:
```typescript
export function createApollo(httpLink: HttpLink): ApolloClientOptions<any> {
  return {
    link: createPersistedQueryLink({
      sha256: (...args) => CryptoES.SHA256(...args).toString(),
    }).concat(httpLink.create({
      uri: environment.graphqlEndpoint,
    })),
    cache: new InMemoryCache(),
    defaultOptions: {
      query: {
        fetchPolicy: 'network-only'
      }
    }
  };
}
```

Used graphql-spring-boot versions:
```xml
        <dependency>
            <groupId>com.graphql-java-kickstart</groupId>
            <artifactId>graphql-kickstart-spring-boot-starter-webflux</artifactId>
            <version>11.1.0</version>
        </dependency>
        <dependency>
            <groupId>com.graphql-java-kickstart</groupId>
            <artifactId>graphql-kickstart-spring-boot-starter-tools</artifactId>
            <version>11.1.0</version>
        </dependency>
```

Please let me know your feedback/comments/thoughts in order to have the fix merged :)