### PR TITLE
Function for GraphQLTestTemplate to upload files using Upload scalar

### DIFF
--- a/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestTemplate.java
+++ b/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/GraphQLTestTemplate.java
@@ -246,7 +246,17 @@ public class GraphQLTestTemplate {
     return post(payload);
   }
 
-  /** Generate GraphQL payload, which consist of 3 elements: query, operationName and variables */
+  /**
+   * Generate GraphQL payload, which consist of 3 elements: query, operationName and variables
+   *
+   * @param graphqlResource path to the classpath resource containing the GraphQL query
+   * @param operationName the name of the GraphQL operation to be executed
+   * @param variables the input variables for the GraphQL query
+   * @param fragmentResources an ordered list of classpath resources containing GraphQL fragment
+   *     definitions.
+   * @return the payload
+   * @throws IOException if the resource cannot be loaded from the classpath
+   */
   private String getPayload(
       String graphqlResource,
       String operationName,

--- a/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/RequestFactory.java
+++ b/graphql-spring-boot-test/src/main/java/com/graphql/spring/boot/test/RequestFactory.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 class RequestFactory {
 
@@ -21,6 +22,12 @@ class RequestFactory {
     LinkedMultiValueMap<String, Object> values = new LinkedMultiValueMap<>();
     values.add("query", forJson(query, new HttpHeaders()));
     values.add("variables", forJson(variables, new HttpHeaders()));
+    return new HttpEntity<>(values, headers);
+  }
+
+  static HttpEntity<Object> forMultipart(
+      MultiValueMap<String, Object> values, HttpHeaders headers) {
+    headers.setContentType(MediaType.MULTIPART_FORM_DATA);
     return new HttpEntity<>(values, headers);
   }
 }

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestTemplateIntegrationTest.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestTemplateIntegrationTest.java
@@ -244,7 +244,7 @@ class GraphQLTestTemplateIntegrationTest {
     ArrayNode nodes = objectMapper.valueToTree(Arrays.asList(null, null));
     variables.putArray(FILES_STRING_NAME).addAll(nodes);
 
-    List<String> fileNames = List.of("multiple-queries.graphql", "simple-test-query.graphql");
+    List<String> fileNames = Arrays.asList("multiple-queries.graphql", "simple-test-query.graphql");
     List<ClassPathResource> testUploadFiles =
         fileNames.stream().map(ClassPathResource::new).collect(Collectors.toList());
     // WHEN - THEN
@@ -263,7 +263,7 @@ class GraphQLTestTemplateIntegrationTest {
     final ObjectNode variables = objectMapper.createObjectNode();
     variables.put(UPLOADING_FILE_STRING_NAME, objectMapper.valueToTree(null));
 
-    List<String> fileNames = List.of("multiple-queries.graphql");
+    List<String> fileNames = Arrays.asList("multiple-queries.graphql");
     List<ClassPathResource> testUploadFiles =
         fileNames.stream().map(ClassPathResource::new).collect(Collectors.toList());
     // WHEN - THEN

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestTemplateIntegrationTest.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/GraphQLTestTemplateIntegrationTest.java
@@ -31,11 +31,13 @@ class GraphQLTestTemplateIntegrationTest {
   private static final String QUERY_WITH_VARIABLES = "query-with-variables.graphql";
   private static final String COMPLEX_TEST_QUERY = "complex-query.graphql";
   private static final String MULTIPLE_QUERIES = "multiple-queries.graphql";
-  private static final String UPLOAD_MUTATION = "upload-files.graphql";
+  private static final String UPLOAD_FILES_MUTATION = "upload-files.graphql";
+  private static final String UPLOAD_FILE_MUTATION = "upload-file.graphql";
   private static final String INPUT_STRING_VALUE = "input-value";
   private static final String INPUT_STRING_NAME = "input";
   private static final String INPUT_HEADER_NAME = "headerName";
   private static final String FILES_STRING_NAME = "files";
+  private static final String UPLOADING_FILE_STRING_NAME = "uploadingFile";
   private static final String TEST_HEADER_NAME = "x-test";
   private static final String TEST_HEADER_VALUE = String.valueOf(UUID.randomUUID());
   private static final String FOO = "FOO";
@@ -47,6 +49,7 @@ class GraphQLTestTemplateIntegrationTest {
   private static final String DATA_FIELD_QUERY_WITH_HEADER = "$.data.queryWithHeader";
   private static final String DATA_FIELD_DUMMY = "$.data.dummy";
   private static final String DATA_FILE_UPLOAD_FILES = "$.data.uploadFiles";
+  private static final String DATA_FILE_UPLOAD_FILE = "$.data.uploadFile";
   private static final String OPERATION_NAME_WITH_VARIABLES = "withVariable";
   private static final String OPERATION_NAME_TEST_QUERY_1 = "testQuery1";
   private static final String OPERATION_NAME_TEST_QUERY_2 = "testQuery2";
@@ -246,10 +249,29 @@ class GraphQLTestTemplateIntegrationTest {
         fileNames.stream().map(ClassPathResource::new).collect(Collectors.toList());
     // WHEN - THEN
     graphQLTestTemplate
-        .postFiles(UPLOAD_MUTATION, variables, testUploadFiles)
+        .postFiles(UPLOAD_FILES_MUTATION, variables, testUploadFiles)
         .assertThatNoErrorsArePresent()
         .assertThatField(DATA_FILE_UPLOAD_FILES)
         .asListOf(String.class)
         .isEqualTo(fileNames);
+  }
+
+  @Test
+  @DisplayName("Test perform with individual file upload and custom path.")
+  void testPerformWithIndividualFileUpload() throws IOException {
+    // GIVEN
+    final ObjectNode variables = objectMapper.createObjectNode();
+    variables.put(UPLOADING_FILE_STRING_NAME, objectMapper.valueToTree(null));
+
+    List<String> fileNames = List.of("multiple-queries.graphql");
+    List<ClassPathResource> testUploadFiles =
+        fileNames.stream().map(ClassPathResource::new).collect(Collectors.toList());
+    // WHEN - THEN
+    graphQLTestTemplate
+        .postFiles(UPLOAD_FILE_MUTATION, variables, testUploadFiles, index -> "variables.file")
+        .assertThatNoErrorsArePresent()
+        .assertThatField(DATA_FILE_UPLOAD_FILE)
+        .asString()
+        .isEqualTo(fileNames.get(0));
   }
 }

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/beans/DummyMutation.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/beans/DummyMutation.java
@@ -24,4 +24,9 @@ public class DummyMutation implements GraphQLMutationResolver {
     List<Part> actualFiles = env.getArgument("files");
     return actualFiles.stream().map(Part::getSubmittedFileName).collect(Collectors.toList());
   }
+
+  public String uploadFile(Part file, DataFetchingEnvironment env) {
+    Part actualFile = env.getArgument("file");
+    return actualFile.getSubmittedFileName();
+  }
 }

--- a/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/beans/DummyMutation.java
+++ b/graphql-spring-boot-test/src/test/java/com/graphql/spring/boot/test/beans/DummyMutation.java
@@ -1,0 +1,27 @@
+package com.graphql.spring.boot.test.beans;
+
+import graphql.kickstart.servlet.apollo.ApolloScalars;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLScalarType;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.servlet.http.Part;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DummyMutation implements GraphQLMutationResolver {
+
+  @Bean
+  private GraphQLScalarType getUploadScalar() {
+    // since the test doesn't inject this built-in Scalar,
+    // so we inject here for test run purpose
+    return ApolloScalars.Upload;
+  }
+
+  public List<String> uploadFiles(List<Part> files, DataFetchingEnvironment env) {
+    List<Part> actualFiles = env.getArgument("files");
+    return actualFiles.stream().map(Part::getSubmittedFileName).collect(Collectors.toList());
+  }
+}

--- a/graphql-spring-boot-test/src/test/resources/test-schema.graphqls
+++ b/graphql-spring-boot-test/src/test/resources/test-schema.graphqls
@@ -1,3 +1,5 @@
+scalar Upload
+
 type FooBar {
     foo: String!
     bar: String!
@@ -17,4 +19,8 @@ type Query {
     fooBar(foo: String, bar: String): FooBar!
     queryWithVariables(input: String!): String!
     queryWithHeader(headerName: String!): String
+}
+
+type Mutation {
+    uploadFiles(files: [Upload]!): [String!]
 }

--- a/graphql-spring-boot-test/src/test/resources/test-schema.graphqls
+++ b/graphql-spring-boot-test/src/test/resources/test-schema.graphqls
@@ -23,4 +23,5 @@ type Query {
 
 type Mutation {
     uploadFiles(files: [Upload]!): [String!]
+    uploadFile(file: Upload): String!
 }

--- a/graphql-spring-boot-test/src/test/resources/upload-file.graphql
+++ b/graphql-spring-boot-test/src/test/resources/upload-file.graphql
@@ -1,0 +1,3 @@
+mutation($file: Upload) {
+    uploadFile(file: $file)
+}

--- a/graphql-spring-boot-test/src/test/resources/upload-files.graphql
+++ b/graphql-spring-boot-test/src/test/resources/upload-files.graphql
@@ -1,0 +1,3 @@
+mutation($files: [Upload]!) {
+    uploadFiles(files: $files)
+}


### PR DESCRIPTION
Came across GraphQL file upload functionality and recognised the `GraphQLTestTemplate` is missing function to handle multi-part file upload for IntegrationTest scenarios. 

The current multipart post function for `GraphQLTestTemplate` is not handling file upload case using built-in [Apollo Upload scalar](https://github.com/graphql-java-kickstart/graphql-java-servlet/blob/eb4dfdb5c0198adc1b4d4466c3b4ea4a77def5d1/graphql-java-servlet/src/main/java/graphql/kickstart/servlet/apollo/ApolloScalars.java) from GraphQL Servlet.

Please note that we can't embed binary data into json. Clients library supporting GraphQL file upload will set `variable.files` to `null` for every element inside the array to make it conformed with json blob spec for `operations` part. However, each file will be a part of multipart request with its binary data. For anyone interested, can check out this library for React https://github.com/jaydenseric/apollo-upload-client

GraphQL Servlet will use `map` part to walk through `variables.files` and validate the request in combination with other binary file parts

Example of an Http Request to upload two files using GraphQL:

```
----------------------------dummyid
Content-Disposition: form-data; name="operations"

{ 
      "query": "mutation($files:[Upload]!) {uploadFiles(files:$files)}", 
      "operationName": "uploadFiles", 
      "variables": { "files": [null, null] } 
}
----------------------------dummyid
Content-Disposition: form-data; name="map"

{ 
     "1":["variables.files.0"], 
     "2":["variables.files.1"] 
}
----------------------------dummyid
Content-Disposition: form-data; name="1"; filename="file1.pdf"
Content-Type: application/octet-stream

<file 1 binary code>
----------------------------dummyid
Content-Disposition: form-data; name="2"; filename="file2.pdf"
Content-Type: application/octet-stream

<file 2 binary code>
```

First time raising PR so please bear with me.