### PR TITLE
ci: update java 16 to 17 for PR test run, change distribution to temurin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache Gradle
         uses: actions/cache@v2
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache Gradle
         uses: actions/cache@v2
@@ -84,7 +84,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
       - name: Cache SonarCloud packages
         uses: actions/cache@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        java: [ 8, 11, 16 ]
+        java: [ 8, 11, 17 ]
     needs: [ validation, commitlint ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Cache Gradle
         uses: actions/cache@v2
@@ -85,7 +85,7 @@ jobs:
         if: env.SONAR_TOKEN != null
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
       - name: Cache SonarCloud packages
         if: env.SONAR_TOKEN != null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache Gradle
         uses: actions/cache@v2
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache Gradle
         uses: actions/cache@v2


### PR DESCRIPTION
Eclipse Temurin is the successor of AdoptOpenJDK.