### PR TITLE
fix(#736): make exception handlers work with Spring proxies

### DIFF
--- a/graphql-kickstart-spring-support/src/main/java/graphql/kickstart/spring/error/GraphQLErrorHandlerFactory.java
+++ b/graphql-kickstart-spring-support/src/main/java/graphql/kickstart/spring/error/GraphQLErrorHandlerFactory.java
@@ -9,6 +9,7 @@ import graphql.kickstart.execution.error.GraphQLErrorHandler;
 import java.util.Arrays;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
@@ -47,6 +48,7 @@ public class GraphQLErrorHandlerFactory {
         return emptyList();
       }
       return Arrays.stream(objClz.getDeclaredMethods())
+          .map(method -> AopUtils.getMostSpecificMethod(method, objClz))
           .filter(ReflectiveMethodValidator::isGraphQLExceptionHandler)
           .map(method -> withReflection(context.getBean(name), method))
           .collect(toList());


### PR DESCRIPTION
While scanning in search of GraphQL error handlers, `GraphQLErrorHandlerFactory` takes into consideration the original method if the bean it's working on is a Spring CGLIB proxy.

In this way, methods annotated with `@ExceptionHandler` are detected as GraphQL error handlers even if the containing bean is wrapped inside a Spring AOP proxy.