### PR TITLE
Graphiql static resource loading fix

### DIFF
--- a/graphql-spring-boot-autoconfigure/src/main/java/graphql/kickstart/autoconfigure/editor/graphiql/GraphiQLAutoConfiguration.java
+++ b/graphql-spring-boot-autoconfigure/src/main/java/graphql/kickstart/autoconfigure/editor/graphiql/GraphiQLAutoConfiguration.java
@@ -3,12 +3,20 @@ package graphql.kickstart.autoconfigure.editor.graphiql;
 import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type.REACTIVE;
 import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type.SERVLET;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;;
 
 /**
  * @author Andrew Potter
@@ -30,5 +38,28 @@ public class GraphiQLAutoConfiguration {
   @ConditionalOnWebApplication(type = REACTIVE)
   ReactiveGraphiQLController reactiveGraphiQLController(GraphiQLProperties properties) {
     return new ReactiveGraphiQLController(properties);
+  }
+
+  @Bean
+  @ConditionalOnWebApplication(type = REACTIVE)
+  @ConditionalOnExpression("'${graphql.graphiql.cdn.enabled:false}' == 'false'")
+  public RouterFunction<ServerResponse> graphiqlStaticFilesRouter() {
+
+    return RouterFunctions.resources(
+        "/vendor/graphiql/**", new ClassPathResource("static/vendor/graphiql/"));
+  }
+
+  @Configuration
+  @EnableWebMvc
+  @ConditionalOnWebApplication(type = SERVLET)
+  @ConditionalOnExpression("'${graphql.graphiql.cdn.enabled:false}' == 'false'")
+  public static class GraphiQLWebMvcResourceConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+
+      registry.addResourceHandler("/vendor/graphiql/**")
+          .addResourceLocations(new ClassPathResource("static/vendor/graphiql/"));
+    }
   }
 }

--- a/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/autoconfigure/editor/graphiql/GraphiQLEnabledTest.java
+++ b/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/autoconfigure/editor/graphiql/GraphiQLEnabledTest.java
@@ -20,7 +20,10 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {GraphiQLAutoConfiguration.class})
+@SpringBootTest(classes = {
+    GraphiQLAutoConfiguration.class,
+    GraphiQLAutoConfiguration.GraphiQLWebMvcResourceConfiguration.class
+})
 @AutoConfigureMockMvc
 @TestPropertySource("classpath:enabled-config.properties")
 class GraphiQLEnabledTest {
@@ -39,6 +42,17 @@ class GraphiQLEnabledTest {
         .perform(get("/graphiql"))
         .andExpect(status().isOk())
         .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+        .andExpect(content().string(not(is(emptyString()))))
+        .andReturn();
+  }
+
+  @Test
+  void graphiqlResourceShouldBeAvailableAtDefaultEndpoint() throws Exception {
+
+    mockMvc
+        .perform(get("/vendor/graphiql/favicon.ico"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith("image/x-icon"))
         .andExpect(content().string(not(is(emptyString()))))
         .andReturn();
   }

--- a/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/autoconfigure/editor/graphiql/ReactiveGraphiQLEnabledTest.java
+++ b/graphql-spring-boot-autoconfigure/src/test/java/graphql/kickstart/autoconfigure/editor/graphiql/ReactiveGraphiQLEnabledTest.java
@@ -50,4 +50,20 @@ class ReactiveGraphiQLEnabledTest {
     log.info("{}", responseBody);
     assertThat(document.select("head title").text()).isEqualTo("GraphiQL");
   }
+
+  @Test
+  void graphiqlResourceShouldBeAvailableAtDefaultEndpoint() {
+    final String responseBody =
+        webTestClient
+            .get()
+            .uri("/vendor/graphiql/favicon.ico")
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    assertThat(responseBody).isNotNull();
+  }
 }


### PR DESCRIPTION
GraphiQL screen works fine with CDN enabled option but when we try to use hosted version we need to define resources manually. voyager reactive configuration already uses automatic static resource loading.

```java
@ConditionalOnProperty(value = "graphql.graphiql.cdn.enabled", havingValue = "false")
```

did not work properly, that's why I put a if condition there.