### PR TITLE
Made possible to use newer versions of altair over cdn

### DIFF
--- a/graphql-spring-boot-autoconfigure/src/main/java/graphql/kickstart/autoconfigure/editor/altair/AltairController.java
+++ b/graphql-spring-boot-autoconfigure/src/main/java/graphql/kickstart/autoconfigure/editor/altair/AltairController.java
@@ -86,7 +86,9 @@ public class AltairController {
   private boolean isJsSuffixAdded() {
     if (nonNull(altairProperties.getCdn().getVersion())) {
       String[] versionValues = altairProperties.getCdn().getVersion().split("\\.");
-      return isNumeric(versionValues[0]) && parseInt(versionValues[0]) >= 4;
+      return isNumeric(versionValues[0]) && parseInt(versionValues[0]) >= 4
+              // -es2018 version is not published for versions 4.2.0 onwards
+              && versionValues.length > 2 && isNumeric(versionValues[1]) && parseInt(versionValues[1]) < 2;
     }
     return false;
   }


### PR DESCRIPTION
Since version 4.2.0 jsdelivr is not publishing packages with es-2018 suffix

https://www.jsdelivr.com/package/npm/altair-static?path=build%2Fdist

this change would allow me to use altair 4.6.4