### PR TITLE
ClasspathResourceSchemaStringProvider to use full constructor instead of field injection

### DIFF
--- a/graphql-spring-boot-autoconfigure/src/main/java/graphql/kickstart/autoconfigure/tools/ClasspathResourceSchemaStringProvider.java
+++ b/graphql-spring-boot-autoconfigure/src/main/java/graphql/kickstart/autoconfigure/tools/ClasspathResourceSchemaStringProvider.java
@@ -10,18 +10,17 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.Resource;
 
+@Slf4j
+@AllArgsConstructor
 public class ClasspathResourceSchemaStringProvider implements SchemaStringProvider {
 
-  @Autowired private ApplicationContext applicationContext;
+  private ApplicationContext applicationContext;
   private String schemaLocationPattern;
-
-  public ClasspathResourceSchemaStringProvider(String schemaLocationPattern) {
-    this.schemaLocationPattern = schemaLocationPattern;
-  }
 
   @Override
   public List<String> schemaStrings() throws IOException {

--- a/graphql-spring-boot-autoconfigure/src/main/java/graphql/kickstart/autoconfigure/tools/GraphQLJavaToolsAutoConfiguration.java
+++ b/graphql-spring-boot-autoconfigure/src/main/java/graphql/kickstart/autoconfigure/tools/GraphQLJavaToolsAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 
 /** @author Andrew Potter */
@@ -52,8 +53,14 @@ public class GraphQLJavaToolsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public SchemaStringProvider schemaStringProvider(GraphQLToolsProperties props) {
-    return new ClasspathResourceSchemaStringProvider(props.getSchemaLocationPattern());
+  public SchemaStringProvider schemaStringProvider(
+      ApplicationContext applicationContext,
+      GraphQLToolsProperties props
+  ) {
+    return new ClasspathResourceSchemaStringProvider(
+        applicationContext,
+        props.getSchemaLocationPattern()
+    );
   }
 
   @Bean


### PR DESCRIPTION
Hello,

I have tried to use native SB3 builds and faced NPE problem. It's related to graalvm nature of compile time boot.

The following changes helped me to solve it, please take a look
Thank you